### PR TITLE
Fix remaining BayesIQBoss org reference in Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /
 # Clone audit kit from private GitHub repo
 ARG GITHUB_TOKEN
 RUN git clone --depth 1 \
-    https://x-access-token:${GITHUB_TOKEN}@github.com/BayesIQBoss/bayesiq-data-audit-kit.git \
+    https://x-access-token:${GITHUB_TOKEN}@github.com/Bayes-IQ/bayesiq-data-audit-kit.git \
     /tmp/audit-kit && \
     mkdir -p /app/bayesiq-data-audit-kit && \
     cp -r /tmp/audit-kit/audit /tmp/audit-kit/requirements.txt /tmp/audit-kit/config /tmp/audit-kit/templates /tmp/audit-kit/manifests /tmp/audit-kit/verticals /app/bayesiq-data-audit-kit/ 2>/dev/null; \


### PR DESCRIPTION
## Summary
- Updates the last BayesIQBoss reference in server/Dockerfile to Bayes-IQ to complete the org rename migration

## Test plan
- [x] grep -r BayesIQBoss returns no results
- [ ] Docker build succeeds with updated clone URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)