### PR TITLE
Rewrite 02: Homepage — router-style landing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import SectionReveal from "@/components/SectionReveal";
+import PathCard from "@/components/PathCard";
+import ProofStrip from "@/components/ProofStrip";
+import GovernanceChain from "@/components/GovernanceChain";
+import { SHOW_SOCIAL_PROOF } from "@/lib/flags";
 
 export const metadata: Metadata = {
   title: "BayesIQ — Governed Analytics",
@@ -9,30 +14,145 @@ export const metadata: Metadata = {
 
 export default function HomePage() {
   return (
-    <section className="px-6 py-24 md:py-32">
-      <div className="mx-auto max-w-3xl text-center">
-        <h1 className="font-display text-4xl font-bold tracking-tight text-bayesiq-900 md:text-5xl">
-          BayesIQ — Governed Analytics
-        </h1>
-        <p className="mt-6 text-lg leading-relaxed text-bayesiq-600">
-          We help teams find broken metrics, fix data pipelines, and build
-          governed analytics infrastructure they can trust.
-        </p>
-        <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-          <Link
-            href="/consulting"
-            className="rounded-lg bg-bayesiq-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
-          >
-            Consulting
-          </Link>
-          <Link
-            href="/platform"
-            className="text-sm font-medium text-bayesiq-600 transition-colors hover:text-bayesiq-900"
-          >
-            Platform &rarr;
-          </Link>
+    <>
+      {/* ──────────────────────────────────────────────
+          Section 1: Hero
+          ──────────────────────────────────────────── */}
+      <section className="px-6 py-24 md:py-32">
+        <div className="mx-auto max-w-3xl text-center">
+          <h1 className="font-display text-4xl font-bold leading-tight tracking-tight text-bayesiq-900 md:text-6xl">
+            Your metrics are wrong.
+            <br />
+            Your AI can&apos;t prove they&apos;re right.
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-bayesiq-600">
+            BayesIQ delivers governed analytics — whether you need us hands-on
+            or want the platform embedded in your workflow. Every finding
+            reviewed. Every decision attributed.
+          </p>
+          <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link
+              href="/assessment"
+              className="rounded-lg bg-bayesiq-900 px-8 py-3.5 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
+            >
+              Take the Assessment
+            </Link>
+            <Link
+              href="/contact"
+              className="text-sm font-medium text-bayesiq-600 transition-colors hover:text-bayesiq-900"
+            >
+              Talk to Us &rarr;
+            </Link>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+
+      {/* ──────────────────────────────────────────────
+          Section 2: Two-Path Cards
+          ──────────────────────────────────────────── */}
+      <section className="bg-bayesiq-50 px-6 py-20 md:py-24">
+        <SectionReveal>
+          <div className="mx-auto max-w-5xl">
+            <div className="grid gap-8 md:grid-cols-2">
+              <PathCard
+                headline="Fix Your Metrics"
+                description="Audit-first analytics consulting. We find what's broken, fix it, and hand you the infrastructure to keep it right."
+                audience="For data team leads, VPs Analytics, and CFOs"
+                href="/consulting"
+                cta="Explore Consulting"
+                variant="primary"
+              />
+              <PathCard
+                headline="Govern Your AI Outputs"
+                description="The governance layer that produces an auditable chain from raw AI output to approved deliverable."
+                audience="For CTOs, compliance leads, and technical operators"
+                href="/platform"
+                cta="Explore the Platform"
+                variant="secondary"
+              />
+            </div>
+          </div>
+        </SectionReveal>
+      </section>
+
+      {/* ──────────────────────────────────────────────
+          Section 3: Proof Strip
+          ──────────────────────────────────────────── */}
+      <section className="px-6 py-20 md:py-24">
+        <SectionReveal>
+          <div className="mx-auto max-w-4xl">
+            <ProofStrip />
+          </div>
+        </SectionReveal>
+      </section>
+
+      {/* ──────────────────────────────────────────────
+          Section 4: Governance Chain
+          ──────────────────────────────────────────── */}
+      <section className="bg-bayesiq-900 px-6 py-20 md:py-24">
+        <SectionReveal>
+          <div className="mx-auto max-w-3xl text-center">
+            <GovernanceChain variant="simple" theme="light" />
+            <p className="mt-10 text-lg leading-relaxed text-bayesiq-300">
+              Every finding reviewed. Every decision attributed.
+              <br className="hidden sm:inline" />
+              Every transition evidence-backed.
+            </p>
+          </div>
+        </SectionReveal>
+      </section>
+
+      {/* ──────────────────────────────────────────────
+          Section 5: Assessment CTA
+          ──────────────────────────────────────────── */}
+      <section className="px-6 py-20 md:py-24">
+        <SectionReveal>
+          <div className="mx-auto max-w-2xl text-center">
+            <h2 className="font-display text-3xl font-bold tracking-tight text-bayesiq-900 md:text-4xl">
+              How reliable is your data?
+            </h2>
+            <p className="mt-4 text-lg text-bayesiq-600">
+              Find out in 2 minutes.
+            </p>
+            <Link
+              href="/assessment"
+              className="mt-8 inline-block rounded-lg bg-bayesiq-900 px-8 py-3.5 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
+            >
+              Take the Assessment
+            </Link>
+          </div>
+        </SectionReveal>
+      </section>
+
+      {/* ──────────────────────────────────────────────
+          Section 6: Social Proof (hidden until content ready)
+          ──────────────────────────────────────────── */}
+      <section
+        data-testid="social-proof"
+        className={`bg-bayesiq-50 px-6 py-20 md:py-24 ${
+          SHOW_SOCIAL_PROOF ? "" : "hidden"
+        }`}
+        aria-hidden={!SHOW_SOCIAL_PROOF}
+      >
+        <div className="mx-auto max-w-5xl">
+          {/* Logo bar placeholder */}
+          <div className="flex items-center justify-center gap-12">
+            <span className="text-sm text-bayesiq-400">
+              Client logos will appear here
+            </span>
+          </div>
+
+          {/* Quote pull placeholder */}
+          <blockquote className="mt-12 text-center">
+            <p className="text-lg italic text-bayesiq-600">
+              &ldquo;Quote placeholder&rdquo;
+            </p>
+            <footer className="mt-4 text-sm text-bayesiq-400">
+              — Name, Title, Company
+            </footer>
+          </blockquote>
+        </div>
+      </section>
+    </>
   );
 }

--- a/src/components/GovernanceChain.tsx
+++ b/src/components/GovernanceChain.tsx
@@ -1,0 +1,180 @@
+interface GovernanceChainNode {
+  label: string;
+}
+
+interface GovernanceChainProps {
+  /** Nodes to display in the chain */
+  nodes?: GovernanceChainNode[];
+  /** "simple" for homepage, "expanded" for platform page */
+  variant?: "simple" | "expanded";
+  /** Whether to animate continuously (platform page only) */
+  animate?: boolean;
+  /** Color theme: "light" for dark backgrounds, "dark" for light backgrounds */
+  theme?: "light" | "dark";
+}
+
+const defaultNodes: GovernanceChainNode[] = [
+  { label: "Raw Data" },
+  { label: "Reviewed" },
+  { label: "Approved" },
+];
+
+export default function GovernanceChain({
+  nodes = defaultNodes,
+  variant = "simple",
+  theme = "dark",
+}: GovernanceChainProps) {
+  const nodeRadius = variant === "simple" ? 20 : 24;
+  const nodeSpacing = variant === "simple" ? 160 : 200;
+
+  // Theme-aware colors
+  const nodeFill =
+    theme === "light" ? "var(--color-bayesiq-200)" : "var(--color-bayesiq-900)";
+  const nodeText = theme === "light" ? "var(--color-bayesiq-900)" : "white";
+  const connectorColor =
+    theme === "light" ? "var(--color-bayesiq-500)" : "var(--color-bayesiq-300)";
+  const labelColor =
+    theme === "light" ? "var(--color-bayesiq-300)" : "var(--color-bayesiq-600)";
+
+  // Horizontal layout dimensions
+  const svgWidth = (nodes.length - 1) * nodeSpacing + nodeRadius * 2 + 40;
+  const svgHeight = 100;
+  const startX = nodeRadius + 20;
+  const centerY = 36;
+
+  // Vertical layout dimensions (mobile)
+  const verticalSpacing = 80;
+  const svgHeightVertical =
+    (nodes.length - 1) * verticalSpacing + nodeRadius * 2 + 60;
+  const centerX = 60;
+  const startY = nodeRadius + 20;
+
+  return (
+    <div data-testid="governance-chain">
+      {/* Desktop: horizontal */}
+      <svg
+        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+        className="mx-auto hidden w-full max-w-lg md:block"
+        role="img"
+        aria-label={`Governance chain: ${nodes.map((n) => n.label).join(" to ")}`}
+      >
+        {nodes.map((node, i) => {
+          const x = startX + i * nodeSpacing;
+
+          return (
+            <g key={node.label}>
+              {/* Connector line to next node */}
+              {i < nodes.length - 1 && (
+                <>
+                  <line
+                    x1={x + nodeRadius}
+                    y1={centerY}
+                    x2={startX + (i + 1) * nodeSpacing - nodeRadius}
+                    y2={centerY}
+                    stroke={connectorColor}
+                    strokeWidth={2}
+                  />
+                  {/* Arrow head */}
+                  <polygon
+                    points={`${startX + (i + 1) * nodeSpacing - nodeRadius - 6},${centerY - 4} ${startX + (i + 1) * nodeSpacing - nodeRadius},${centerY} ${startX + (i + 1) * nodeSpacing - nodeRadius - 6},${centerY + 4}`}
+                    fill={connectorColor}
+                  />
+                </>
+              )}
+
+              {/* Node circle */}
+              <circle cx={x} cy={centerY} r={nodeRadius} fill={nodeFill} />
+
+              {/* Checkmark inside circle */}
+              <text
+                x={x}
+                y={centerY + 1}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fill={nodeText}
+                fontSize={variant === "simple" ? 14 : 16}
+                fontFamily="var(--font-sans)"
+              >
+                {i === 0 ? "\u25CB" : "\u2713"}
+              </text>
+
+              {/* Label below */}
+              <text
+                x={x}
+                y={centerY + nodeRadius + 20}
+                textAnchor="middle"
+                fill={labelColor}
+                fontSize={13}
+                fontFamily="var(--font-sans)"
+              >
+                {node.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* Mobile: vertical */}
+      <svg
+        viewBox={`0 0 120 ${svgHeightVertical}`}
+        className="mx-auto block w-28 md:hidden"
+        role="img"
+        aria-label={`Governance chain: ${nodes.map((n) => n.label).join(" to ")}`}
+      >
+        {nodes.map((node, i) => {
+          const y = startY + i * verticalSpacing;
+
+          return (
+            <g key={node.label}>
+              {/* Connector line to next node */}
+              {i < nodes.length - 1 && (
+                <>
+                  <line
+                    x1={centerX}
+                    y1={y + nodeRadius}
+                    x2={centerX}
+                    y2={startY + (i + 1) * verticalSpacing - nodeRadius}
+                    stroke={connectorColor}
+                    strokeWidth={2}
+                  />
+                  <polygon
+                    points={`${centerX - 4},${startY + (i + 1) * verticalSpacing - nodeRadius - 6} ${centerX},${startY + (i + 1) * verticalSpacing - nodeRadius} ${centerX + 4},${startY + (i + 1) * verticalSpacing - nodeRadius - 6}`}
+                    fill={connectorColor}
+                  />
+                </>
+              )}
+
+              {/* Node circle */}
+              <circle cx={centerX} cy={y} r={nodeRadius} fill={nodeFill} />
+
+              {/* Icon */}
+              <text
+                x={centerX}
+                y={y + 1}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fill={nodeText}
+                fontSize={14}
+                fontFamily="var(--font-sans)"
+              >
+                {i === 0 ? "\u25CB" : "\u2713"}
+              </text>
+
+              {/* Label to the right */}
+              <text
+                x={centerX + nodeRadius + 10}
+                y={y + 1}
+                dominantBaseline="central"
+                fill={labelColor}
+                fontSize={12}
+                fontFamily="var(--font-sans)"
+              >
+                {node.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/src/components/PathCard.tsx
+++ b/src/components/PathCard.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+
+interface PathCardProps {
+  /** Card headline in display font */
+  headline: string;
+  /** 1-2 line description */
+  description: string;
+  /** Target audience label */
+  audience: string;
+  /** Link destination (must be /consulting or /platform) */
+  href: "/consulting" | "/platform";
+  /** CTA button text */
+  cta: string;
+  /** Visual variant: primary gets more visual weight */
+  variant?: "primary" | "secondary";
+}
+
+export default function PathCard({
+  headline,
+  description,
+  audience,
+  href,
+  cta,
+  variant = "primary",
+}: PathCardProps) {
+  const isPrimary = variant === "primary";
+
+  return (
+    <div
+      data-testid="path-card"
+      className={`flex flex-col justify-between rounded-2xl border p-8 transition-shadow hover:shadow-lg md:p-10 ${
+        isPrimary
+          ? "border-bayesiq-200 bg-white"
+          : "border-bayesiq-200 bg-bayesiq-50"
+      }`}
+    >
+      <div>
+        <h3 className="font-display text-2xl font-bold tracking-tight text-bayesiq-900 md:text-3xl">
+          {headline}
+        </h3>
+        <p className="mt-4 text-base leading-relaxed text-bayesiq-600">
+          {description}
+        </p>
+        <p className="mt-4 text-sm font-medium text-bayesiq-400">
+          {audience}
+        </p>
+      </div>
+      <div className="mt-8">
+        <Link
+          href={href}
+          className={`inline-block rounded-lg px-6 py-3 text-sm font-medium transition-colors ${
+            isPrimary
+              ? "bg-bayesiq-900 text-white hover:bg-bayesiq-800"
+              : "border border-bayesiq-300 bg-white text-bayesiq-900 hover:bg-bayesiq-50"
+          }`}
+        >
+          {cta}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProofStrip.tsx
+++ b/src/components/ProofStrip.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import StatCounter from "@/components/StatCounter";
+
+interface Stat {
+  value: number;
+  prefix?: string;
+  suffix?: string;
+  label: string;
+}
+
+const stats: Stat[] = [
+  { value: 12, suffix: "+", label: "Quality Checks" },
+  { value: 80, suffix: "%", label: "Less Debug Time" },
+  { value: 87, prefix: "", suffix: "", label: "Avg Score After" },
+];
+
+export default function ProofStrip() {
+  return (
+    <div
+      data-testid="proof-strip"
+      className="grid grid-cols-1 gap-8 sm:grid-cols-3"
+    >
+      {stats.map((stat) => (
+        <div key={stat.label} className="text-center" data-testid="stat-item">
+          <p className="text-4xl font-bold text-bayesiq-900 md:text-5xl">
+            <StatCounter
+              value={stat.value}
+              prefix={stat.prefix}
+              suffix={stat.suffix}
+            />
+          </p>
+          <p className="mt-2 text-sm font-medium text-bayesiq-500">
+            {stat.label}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/SectionReveal.tsx
+++ b/src/components/SectionReveal.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRef } from "react";
+import { motion, useInView } from "framer-motion";
+
+interface SectionRevealProps {
+  children: React.ReactNode;
+  /** Additional class names for the wrapper */
+  className?: string;
+  /** Upward shift distance in pixels (default 20) */
+  shift?: number;
+  /** Animation duration in seconds (default 0.6) */
+  duration?: number;
+  /** Delay before animation starts in seconds (default 0) */
+  delay?: number;
+}
+
+export default function SectionReveal({
+  children,
+  className,
+  shift = 20,
+  duration = 0.6,
+  delay = 0,
+}: SectionRevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const isInView = useInView(ref, { once: true, margin: "-80px" });
+
+  return (
+    <motion.div
+      ref={ref}
+      className={className}
+      initial={{ opacity: 0, y: shift }}
+      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: shift }}
+      transition={{ duration, delay, ease: "easeOut" }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/StatCounter.tsx
+++ b/src/components/StatCounter.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  useInView,
+  useMotionValue,
+  useTransform,
+  animate,
+  useMotionValueEvent,
+} from "framer-motion";
+
+interface StatCounterProps {
+  /** Target number to count up to */
+  value: number;
+  /** Text before the number (e.g. "$") */
+  prefix?: string;
+  /** Text after the number (e.g. "%", "+", "K") */
+  suffix?: string;
+  /** Animation duration in seconds (default 1.5) */
+  duration?: number;
+}
+
+export default function StatCounter({
+  value,
+  prefix = "",
+  suffix = "",
+  duration = 1.5,
+}: StatCounterProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const isInView = useInView(ref, { once: true });
+  const motionValue = useMotionValue(0);
+  const rounded = useTransform(motionValue, (v) => Math.round(v));
+  const [displayValue, setDisplayValue] = useState(0);
+
+  useMotionValueEvent(rounded, "change", (latest) => {
+    setDisplayValue(latest);
+  });
+
+  useEffect(() => {
+    if (isInView) {
+      animate(motionValue, value, { duration, ease: "easeOut" });
+    }
+  }, [isInView, motionValue, value, duration]);
+
+  // Calculate min-width based on target value character count (monospace makes ch reliable)
+  const charCount = value.toString().length + prefix.length + suffix.length;
+
+  return (
+    <span
+      ref={ref}
+      className="inline-block font-mono tabular-nums"
+      style={{ minWidth: `${charCount}ch` }}
+    >
+      {prefix}
+      {displayValue}
+      {suffix}
+    </span>
+  );
+}

--- a/src/components/__tests__/homepage-components.spec.tsx
+++ b/src/components/__tests__/homepage-components.spec.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock framer-motion to avoid animation complexities in tests
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      ...rest
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      [key: string]: unknown;
+    }) => {
+      // Filter out framer-motion-specific props
+      const htmlProps: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(rest)) {
+        if (
+          ![
+            "initial",
+            "animate",
+            "transition",
+            "whileInView",
+            "viewport",
+          ].includes(key)
+        ) {
+          htmlProps[key] = value;
+        }
+      }
+      return (
+        <div className={className} {...htmlProps}>
+          {children}
+        </div>
+      );
+    },
+  },
+  useInView: () => true,
+  useMotionValue: (initial: number) => ({
+    get: () => initial,
+    set: () => {},
+    on: () => () => {},
+  }),
+  useTransform: (_mv: unknown, fn: (v: number) => number) => ({
+    get: () => fn(0),
+    set: () => {},
+    on: () => () => {},
+  }),
+  useMotionValueEvent: () => {
+    // No-op in tests -- StatCounter renders with initial useState(0)
+  },
+  animate: () => ({ stop: () => {} }),
+}));
+
+describe("SectionReveal", () => {
+  it("renders children", async () => {
+    const { default: SectionReveal } = await import(
+      "@/components/SectionReveal"
+    );
+    render(
+      <SectionReveal>
+        <p>Hello world</p>
+      </SectionReveal>
+    );
+    expect(screen.getByText("Hello world")).toBeTruthy();
+  });
+
+  it("applies custom className", async () => {
+    const { default: SectionReveal } = await import(
+      "@/components/SectionReveal"
+    );
+    const { container } = render(
+      <SectionReveal className="my-custom-class">
+        <p>Content</p>
+      </SectionReveal>
+    );
+    expect(container.firstElementChild?.className).toContain("my-custom-class");
+  });
+});
+
+describe("StatCounter", () => {
+  it("renders with monospace font and tabular-nums classes", async () => {
+    const { default: StatCounter } = await import("@/components/StatCounter");
+    const { container } = render(
+      <StatCounter value={42} prefix="$" suffix="K" />
+    );
+    const span = container.querySelector(".font-mono");
+    expect(span).toBeTruthy();
+    expect(span?.className).toContain("tabular-nums");
+    // Prefix and suffix are rendered as text content alongside the number
+    expect(span?.textContent).toContain("$");
+    expect(span?.textContent).toContain("K");
+  });
+
+  it("renders a span element with min-width for layout stability", async () => {
+    const { default: StatCounter } = await import("@/components/StatCounter");
+    const { container } = render(<StatCounter value={100} suffix="+" />);
+    const span = container.querySelector(".font-mono");
+    expect(span).toBeTruthy();
+    // Should have inline style for min-width
+    expect(span?.getAttribute("style")).toContain("min-width");
+  });
+});
+
+describe("GovernanceChain", () => {
+  it("renders correct number of nodes from default props", async () => {
+    const { default: GovernanceChain } = await import(
+      "@/components/GovernanceChain"
+    );
+    render(<GovernanceChain />);
+    const chain = screen.getByTestId("governance-chain");
+    expect(chain).toBeTruthy();
+    // Desktop SVG should have aria-label mentioning all three nodes
+    const svg = chain.querySelector('svg[role="img"]');
+    expect(svg?.getAttribute("aria-label")).toContain("Raw Data");
+    expect(svg?.getAttribute("aria-label")).toContain("Reviewed");
+    expect(svg?.getAttribute("aria-label")).toContain("Approved");
+  });
+
+  it("renders custom nodes", async () => {
+    const { default: GovernanceChain } = await import(
+      "@/components/GovernanceChain"
+    );
+    render(
+      <GovernanceChain
+        nodes={[{ label: "Step A" }, { label: "Step B" }]}
+      />
+    );
+    const chain = screen.getByTestId("governance-chain");
+    const svg = chain.querySelector('svg[role="img"]');
+    expect(svg?.getAttribute("aria-label")).toContain("Step A");
+    expect(svg?.getAttribute("aria-label")).toContain("Step B");
+  });
+
+  it("renders 3 circle elements per SVG for default nodes", async () => {
+    const { default: GovernanceChain } = await import(
+      "@/components/GovernanceChain"
+    );
+    const { container } = render(<GovernanceChain />);
+    // Each SVG (desktop and mobile) should have 3 circles
+    const svgs = container.querySelectorAll("svg");
+    for (const svg of svgs) {
+      const circles = svg.querySelectorAll("circle");
+      expect(circles.length).toBe(3);
+    }
+  });
+});
+
+describe("PathCard", () => {
+  it("renders headline, description, audience, and link", async () => {
+    const { default: PathCard } = await import("@/components/PathCard");
+    render(
+      <PathCard
+        headline="Fix Your Metrics"
+        description="We fix broken analytics."
+        audience="For data leads"
+        href="/consulting"
+        cta="Learn More"
+      />
+    );
+    expect(screen.getByText("Fix Your Metrics")).toBeTruthy();
+    expect(screen.getByText("We fix broken analytics.")).toBeTruthy();
+    expect(screen.getByText("For data leads")).toBeTruthy();
+    const link = screen.getByText("Learn More");
+    expect(link.closest("a")?.getAttribute("href")).toBe("/consulting");
+  });
+
+  it("links to /consulting or /platform only", async () => {
+    const { default: PathCard } = await import("@/components/PathCard");
+    const { rerender } = render(
+      <PathCard
+        headline="Test"
+        description="Test"
+        audience="Test"
+        href="/consulting"
+        cta="Go"
+      />
+    );
+    expect(screen.getByText("Go").closest("a")?.getAttribute("href")).toBe(
+      "/consulting"
+    );
+
+    rerender(
+      <PathCard
+        headline="Test"
+        description="Test"
+        audience="Test"
+        href="/platform"
+        cta="Go"
+      />
+    );
+    expect(screen.getByText("Go").closest("a")?.getAttribute("href")).toBe(
+      "/platform"
+    );
+  });
+});
+
+describe("ProofStrip", () => {
+  it("renders at least 3 stat items", async () => {
+    const { default: ProofStrip } = await import("@/components/ProofStrip");
+    render(<ProofStrip />);
+    const strip = screen.getByTestId("proof-strip");
+    expect(strip).toBeTruthy();
+    const statItems = screen.getAllByTestId("stat-item");
+    expect(statItems.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("flags", () => {
+  it("exports SHOW_SOCIAL_PROOF as false", async () => {
+    const { SHOW_SOCIAL_PROOF } = await import("@/lib/flags");
+    expect(SHOW_SOCIAL_PROOF).toBe(false);
+  });
+});

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -1,0 +1,9 @@
+/**
+ * Feature flags for the BayesIQ website.
+ *
+ * Toggle these to control visibility of sections that are structurally
+ * ready but awaiting content or client approval.
+ */
+
+/** Show the social proof section (logo bar + quote pulls) on the homepage. */
+export const SHOW_SOCIAL_PROOF = false;


### PR DESCRIPTION
## Summary
- Router-style homepage with two-path cards (Consulting / Platform)
- Hero with problem statement in display font
- Proof strip with animated stat counters (framer-motion)
- Governance chain SVG motif (3 nodes: Raw Data → Reviewed → Approved)
- Assessment CTA prominently placed
- Social proof slots (hidden, structurally ready)
- New reusable components: SectionReveal, StatCounter, GovernanceChain, PathCard, ProofStrip

## Test plan
- [x] npm run build passes
- [x] 88 tests pass (77 existing + 11 new)

issue: null