### PR TITLE
Rewrite 04: Consulting hub + industries

### DIFF
--- a/src/app/consulting/industries/page.tsx
+++ b/src/app/consulting/industries/page.tsx
@@ -1,32 +1,56 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import IndustryTabs from "@/components/consulting/IndustryTabs";
+import CTA from "@/components/CTA";
 
 export const metadata: Metadata = {
   title: "Industries",
   description:
-    "BayesIQ works across Fintech, Healthcare, SaaS, and other data-intensive industries to deliver governed analytics and metric validation.",
+    "BayesIQ works across Fintech, Healthcare, SaaS, and Real Estate to audit data pipelines, validate metrics, and deliver governed analytics.",
+  openGraph: {
+    title: "Industries — BayesIQ Consulting",
+    description:
+      "Industry-specific data auditing for Fintech, Healthcare, SaaS, and Real Estate.",
+  },
 };
 
 export default function IndustriesPage() {
   return (
-    <section className="px-6 py-24 md:py-32">
-      <div className="mx-auto max-w-3xl text-center">
-        <h1 className="font-display text-4xl font-bold tracking-tight text-bayesiq-900 md:text-5xl">
-          Industries
-        </h1>
-        <p className="mt-6 text-lg leading-relaxed text-bayesiq-600">
-          Governed analytics for Fintech, Healthcare, SaaS, and other
-          data-intensive industries. Coming soon.
-        </p>
-        <div className="mt-8">
-          <Link
-            href="/consulting"
-            className="text-sm font-medium text-bayesiq-600 transition-colors hover:text-bayesiq-900"
-          >
-            &larr; Back to Consulting
-          </Link>
+    <>
+      {/* Hero */}
+      <section className="px-6 py-24 md:py-32">
+        <div className="mx-auto max-w-3xl text-center">
+          <h1 className="font-display text-4xl font-bold tracking-tight text-bayesiq-900 md:text-5xl">
+            Industries We Serve
+          </h1>
+          <p className="mt-6 text-lg leading-relaxed text-bayesiq-600">
+            Every industry has its own failure patterns. We know what breaks in
+            each one because we have audited it.
+          </p>
+          <p className="mt-4 text-sm text-bayesiq-500">
+            <Link
+              href="/consulting"
+              className="font-medium text-bayesiq-600 transition-colors hover:text-bayesiq-900"
+            >
+              &larr; Back to Consulting
+            </Link>
+          </p>
         </div>
-      </div>
-    </section>
+      </section>
+
+      {/* Tabs */}
+      <section className="border-t border-bayesiq-200 px-6 py-12">
+        <div className="mx-auto max-w-4xl">
+          <IndustryTabs />
+        </div>
+      </section>
+
+      {/* Bottom CTA */}
+      <CTA
+        headline="Every audit starts with a one-week diagnostic."
+        description="Find out what's broken in your data before it reaches a board deck, a regulatory filing, or an investor pitch."
+        buttonText="Book a Diagnostic"
+      />
+    </>
   );
 }

--- a/src/app/consulting/page.tsx
+++ b/src/app/consulting/page.tsx
@@ -1,44 +1,208 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import PipelineSteps from "@/components/consulting/PipelineSteps";
+import EngagementTiers from "@/components/consulting/EngagementTiers";
+import BentoGrid from "@/components/consulting/BentoGrid";
+import BentoCard from "@/components/consulting/BentoCard";
+import FAQAccordion from "@/components/consulting/FAQAccordion";
+import CTA from "@/components/CTA";
 
 export const metadata: Metadata = {
-  title: "Consulting",
+  title: "Audit-First Analytics Consulting",
   description:
-    "BayesIQ consulting services: data audits, metric validation, pipeline remediation, and governed analytics delivery across industries.",
+    "BayesIQ consulting: we find what's broken in your data, fix it, and hand you the infrastructure to keep it right. Methodology, engagement tiers, deliverables.",
+  openGraph: {
+    title: "Audit-First Analytics Consulting — BayesIQ",
+    description:
+      "We find what's broken, fix it, and hand you the infrastructure to keep it right.",
+  },
 };
+
+const deliverables = [
+  {
+    title: "Scored Audit Report (0-100)",
+    description:
+      "A quantified evaluation of your pipeline across completeness, freshness, schema conformance, and metric consistency. Findings ranked by severity and business impact.",
+    span: 2 as const,
+  },
+  {
+    title: "Dataset Profile",
+    description:
+      "Schema scan covering column types, null rates, cardinality, and distributions across every table in your warehouse.",
+    span: 1 as const,
+  },
+  {
+    title: "Quality Checks Report",
+    description:
+      "Results from 40+ automated checks: uniqueness, referential integrity, accepted values, freshness, and near-duplicate detection.",
+    span: 1 as const,
+  },
+  {
+    title: "ASSUMPTIONS.md",
+    description:
+      "A plain-language document capturing every assumption the pipeline makes. Client sign-off before anything is built.",
+    span: 1 as const,
+  },
+  {
+    title: "METRICS.md",
+    description:
+      "One canonical definition per KPI with formulas, dimensions, and validation rules. Aligned across product, finance, and growth.",
+    span: 1 as const,
+  },
+  {
+    title: "dbt Project (40+ tests)",
+    description:
+      "Auto-generated staging-to-mart pipeline with deduplication, canonicalization, and mart models. 40+ schema tests covering nulls, uniqueness, range validation, and freshness.",
+    span: 2 as const,
+  },
+  {
+    title: "Streamlit Dashboard",
+    description:
+      "Interactive dashboards with sidebar filters, metric charts, and data quality views. Built on validated staging models.",
+    span: 1 as const,
+  },
+  {
+    title: "Canonicalization Mapping",
+    description:
+      "Maps raw column names and inconsistent values to clean, canonical forms. The translation layer between messy source data and governed metrics.",
+    span: 1 as const,
+  },
+];
 
 export default function ConsultingPage() {
   return (
-    <section className="px-6 py-24 md:py-32">
-      <div className="mx-auto max-w-3xl text-center">
-        <h1 className="font-display text-4xl font-bold tracking-tight text-bayesiq-900 md:text-5xl">
-          Consulting
-        </h1>
-        <p className="mt-6 text-lg leading-relaxed text-bayesiq-600">
-          Data audits, metric validation, and pipeline remediation for teams
-          that need trustworthy analytics.
-        </p>
-        <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-          <Link
-            href="/consulting/case-studies"
-            className="text-sm font-medium text-bayesiq-600 transition-colors hover:text-bayesiq-900"
-          >
-            Case Studies &rarr;
-          </Link>
-          <Link
-            href="/consulting/sample-report"
-            className="text-sm font-medium text-bayesiq-600 transition-colors hover:text-bayesiq-900"
-          >
-            Sample Report &rarr;
-          </Link>
-          <Link
-            href="/contact"
-            className="rounded-lg bg-bayesiq-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
-          >
-            Get in Touch
-          </Link>
+    <>
+      {/* Hero */}
+      <section className="px-6 py-24 md:py-32">
+        <div className="mx-auto max-w-3xl text-center">
+          <h1 className="font-display text-4xl font-bold tracking-tight text-bayesiq-900 md:text-5xl">
+            Audit-First Analytics Consulting
+          </h1>
+          <p className="mt-6 text-lg leading-relaxed text-bayesiq-600">
+            We find what&apos;s broken, fix it, and hand you the infrastructure
+            to keep it right.
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link
+              href="/contact"
+              className="rounded-lg bg-bayesiq-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
+            >
+              Book a Diagnostic
+            </Link>
+            <Link
+              href="/assessment"
+              className="rounded-lg border border-bayesiq-300 px-6 py-3 text-sm font-medium text-bayesiq-900 transition-colors hover:bg-bayesiq-50"
+            >
+              Take the Self-Assessment
+            </Link>
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+
+      {/* Methodology */}
+      <section className="border-t border-bayesiq-200 bg-bayesiq-50 px-6 py-20">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="font-display text-2xl font-bold tracking-tight text-bayesiq-900">
+            How We Work
+          </h2>
+          <p className="mt-4 text-base leading-relaxed text-bayesiq-600">
+            A repeatable, six-stage pipeline. Every engagement follows the same
+            sequence so nothing gets missed and every finding is traceable back
+            to source data.
+          </p>
+          <div className="mt-10">
+            <PipelineSteps />
+          </div>
+        </div>
+      </section>
+
+      {/* Engagement Tiers */}
+      <section className="border-t border-bayesiq-200 px-6 py-20">
+        <div className="mx-auto max-w-5xl">
+          <div className="text-center">
+            <h2 className="font-display text-2xl font-bold tracking-tight text-bayesiq-900">
+              Engagement Tiers
+            </h2>
+            <p className="mt-4 text-base text-bayesiq-600">
+              Start with a one-week diagnostic. The sprint fee is{" "}
+              <span className="font-mono">100%</span> credited toward a full
+              engagement.
+            </p>
+          </div>
+          <div className="mt-10">
+            <EngagementTiers />
+          </div>
+        </div>
+      </section>
+
+      {/* Deliverables — Bento Grid */}
+      <section className="border-t border-bayesiq-200 bg-bayesiq-50 px-6 py-20">
+        <div className="mx-auto max-w-5xl">
+          <h2 className="font-display text-2xl font-bold tracking-tight text-bayesiq-900">
+            What You Get
+          </h2>
+          <p className="mt-4 text-base text-bayesiq-600">
+            Concrete artifacts, not a slide deck. Every engagement produces
+            working infrastructure your team can use from day one.
+          </p>
+          <div className="mt-10">
+            <BentoGrid>
+              {deliverables.map((d) => (
+                <BentoCard
+                  key={d.title}
+                  title={d.title}
+                  description={d.description}
+                  span={d.span}
+                />
+              ))}
+            </BentoGrid>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="border-t border-bayesiq-200 px-6 py-20">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="font-display text-2xl font-bold tracking-tight text-bayesiq-900">
+            Frequently Asked Questions
+          </h2>
+          <div className="mt-8">
+            <FAQAccordion />
+          </div>
+        </div>
+      </section>
+
+      {/* What We Work With */}
+      <section className="border-t border-bayesiq-200 bg-bayesiq-50 px-6 py-12">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-sm text-bayesiq-500">
+            <span className="font-medium text-bayesiq-700">
+              Warehouses:
+            </span>{" "}
+            Snowflake, BigQuery, Redshift{" "}
+            <span className="mx-2 text-bayesiq-300">|</span>
+            <span className="font-medium text-bayesiq-700">
+              Transform:
+            </span>{" "}
+            dbt preferred, any stack{" "}
+            <span className="mx-2 text-bayesiq-300">|</span>
+            <span className="font-medium text-bayesiq-700">
+              Dashboards:
+            </span>{" "}
+            Looker, Tableau, Mode, Metabase{" "}
+            <span className="mx-2 text-bayesiq-300">|</span>
+            <span className="font-medium text-bayesiq-700">Access:</span>{" "}
+            Read-only
+          </p>
+        </div>
+      </section>
+
+      {/* Bottom CTA */}
+      <CTA
+        headline="Ready to see what's hiding in your data?"
+        description="Book a one-week diagnostic to score your data pipeline and surface the issues that matter most."
+        buttonText="Book a Diagnostic"
+      />
+    </>
   );
 }

--- a/src/components/consulting/BeforeAfter.tsx
+++ b/src/components/consulting/BeforeAfter.tsx
@@ -1,0 +1,48 @@
+/**
+ * Split-screen before/after finding display.
+ * Server component. JetBrains Mono for values.
+ */
+
+interface BeforeAfterProps {
+  beforeLabel: string;
+  beforeValue: string;
+  afterLabel: string;
+  afterValue: string;
+  annotation?: string;
+}
+
+export default function BeforeAfter({
+  beforeLabel,
+  beforeValue,
+  afterLabel,
+  afterValue,
+  annotation,
+}: BeforeAfterProps) {
+  return (
+    <div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {/* Before */}
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+          <p className="text-xs font-medium uppercase tracking-wider text-red-600">
+            {beforeLabel}
+          </p>
+          <p className="mt-1 font-mono text-2xl font-bold text-red-700">
+            {beforeValue}
+          </p>
+        </div>
+        {/* After */}
+        <div className="rounded-lg border border-green-200 bg-green-50 p-4">
+          <p className="text-xs font-medium uppercase tracking-wider text-green-600">
+            {afterLabel}
+          </p>
+          <p className="mt-1 font-mono text-2xl font-bold text-green-700">
+            {afterValue}
+          </p>
+        </div>
+      </div>
+      {annotation && (
+        <p className="mt-3 text-sm text-bayesiq-600">{annotation}</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/consulting/BentoCard.tsx
+++ b/src/components/consulting/BentoCard.tsx
@@ -1,0 +1,32 @@
+/**
+ * Individual bento card for the deliverables grid.
+ * Server component.
+ */
+
+interface BentoCardProps {
+  title: string;
+  description: string;
+  /** 1 = standard (1 col), 2 = large (spans 2 cols) */
+  span?: 1 | 2;
+}
+
+export default function BentoCard({
+  title,
+  description,
+  span = 1,
+}: BentoCardProps) {
+  return (
+    <div
+      className={`rounded-xl border border-bayesiq-200 bg-white p-5 ${
+        span === 2 ? "sm:col-span-2" : ""
+      }`}
+    >
+      <h3 className="font-mono text-sm font-semibold text-bayesiq-900">
+        {title}
+      </h3>
+      <p className="mt-2 text-sm leading-relaxed text-bayesiq-600">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/src/components/consulting/BentoGrid.tsx
+++ b/src/components/consulting/BentoGrid.tsx
@@ -1,0 +1,17 @@
+/**
+ * Reusable bento grid layout wrapper.
+ * Responsive: 1-col mobile, 2-col tablet, 4-col desktop.
+ * Server component.
+ */
+
+interface BentoGridProps {
+  children: React.ReactNode;
+}
+
+export default function BentoGrid({ children }: BentoGridProps) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {children}
+    </div>
+  );
+}

--- a/src/components/consulting/EngagementTiers.tsx
+++ b/src/components/consulting/EngagementTiers.tsx
@@ -1,0 +1,116 @@
+/**
+ * Engagement tier cards.
+ * NO PRICING. Scope and timeline only.
+ * Server component.
+ */
+
+import Link from "next/link";
+
+interface Tier {
+  name: string;
+  timeline: string;
+  description: string;
+  includes: string[];
+  cta: string;
+  highlighted?: boolean;
+}
+
+const tiers: Tier[] = [
+  {
+    name: "Diagnostic Sprint",
+    timeline: "1 week",
+    description:
+      "A fast, low-friction entry point. We connect to your warehouse, run our automated pipeline, and deliver a severity-ranked scorecard of the top issues in your data systems.",
+    includes: [
+      "Scored audit report (0-100)",
+      "Top findings ranked by severity",
+      "Remediation priorities",
+      "Executive summary + technical detail",
+    ],
+    cta: "Book a Diagnostic",
+  },
+  {
+    name: "Full Engagement",
+    timeline: "4-6 weeks",
+    description:
+      "End-to-end: from warehouse connection to validated dashboards. We audit your data, formalize metric definitions, build the fix, and hand it off to your team.",
+    includes: [
+      "Everything in Diagnostic Sprint",
+      "ASSUMPTIONS.md (data contracts)",
+      "METRICS.md (canonical definitions)",
+      "dbt project with 40+ tests",
+      "Interactive Streamlit dashboards",
+      "Drift detection and monitoring",
+    ],
+    cta: "Start a Full Engagement",
+    highlighted: true,
+  },
+  {
+    name: "Continuous Monitoring",
+    timeline: "Ongoing",
+    description:
+      "After the engagement ends, automated monitoring keeps your metrics honest. Drift detection, freshness alerts, and quarterly reviews ensure regressions are caught early.",
+    includes: [
+      "Automated drift detection",
+      "Freshness and volume alerting",
+      "Quarterly audit reviews",
+      "Priority support for new metrics",
+    ],
+    cta: "Learn About Monitoring",
+  },
+];
+
+export default function EngagementTiers() {
+  return (
+    <div className="grid gap-6 md:grid-cols-3">
+      {tiers.map((tier) => (
+        <div
+          key={tier.name}
+          className={`flex flex-col rounded-xl border p-6 ${
+            tier.highlighted
+              ? "border-bayesiq-900 ring-1 ring-bayesiq-900"
+              : "border-bayesiq-200"
+          }`}
+        >
+          {tier.highlighted && (
+            <span className="mb-3 inline-block w-fit rounded-full bg-bayesiq-900 px-3 py-0.5 text-xs font-medium text-white">
+              Most Popular
+            </span>
+          )}
+          <h3 className="font-display text-xl font-semibold text-bayesiq-900">
+            {tier.name}
+          </h3>
+          <p className="mt-1 font-mono text-sm text-bayesiq-500">
+            {tier.timeline}
+          </p>
+          <p className="mt-3 text-sm leading-relaxed text-bayesiq-600">
+            {tier.description}
+          </p>
+          <ul className="mt-4 flex-1 space-y-2">
+            {tier.includes.map((item) => (
+              <li
+                key={item}
+                className="flex items-start gap-2 text-sm text-bayesiq-700"
+              >
+                <span className="mt-1 shrink-0 text-bayesiq-400" aria-hidden="true">
+                  &bull;
+                </span>
+                {item}
+              </li>
+            ))}
+          </ul>
+          <Link
+            href="/contact"
+            className={`mt-6 block rounded-lg px-4 py-2.5 text-center text-sm font-medium transition-colors ${
+              tier.highlighted
+                ? "bg-bayesiq-900 text-white hover:bg-bayesiq-800"
+                : "border border-bayesiq-300 text-bayesiq-900 hover:bg-bayesiq-50"
+            }`}
+          >
+            {tier.cta}
+          </Link>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/consulting/FAQAccordion.tsx
+++ b/src/components/consulting/FAQAccordion.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+/**
+ * Expandable FAQ section.
+ * Client component (needs expand/collapse state).
+ * Uses native <details>/<summary> for zero-JS base with
+ * controlled state for single-open behavior.
+ */
+
+import { useState } from "react";
+
+interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+const defaultFAQs: FAQItem[] = [
+  {
+    question: "Can't our team do this ourselves?",
+    answer:
+      "Most teams we work with have strong data engineers. The issue is not skill but time and focus. Internal teams are busy building pipelines and dashboards. They rarely get dedicated time to audit telemetry and metric correctness end-to-end. We compress months of ad-hoc debugging into a structured 1-2 week engagement. Your team keeps building while we find what is broken.",
+  },
+  {
+    question: "What data access do you need?",
+    answer:
+      "Read-only access to your data warehouse. No write access, no production system access, no PII required. We run queries inside your environment and only export aggregated findings. We operate under NDA with time-limited access scoped to the engagement period. We need about 1-2 hours per week from your data team for context.",
+  },
+  {
+    question:
+      "How is this different from Monte Carlo or Great Expectations?",
+    answer:
+      "Those tools are observability platforms that detect anomalies in data freshness, volume, and schema. That is monitoring. We do something different: we audit whether the business metrics are correct. That means recomputing KPIs from source events, validating telemetry against logging specs at the field level, and tracing root causes through pipeline logic. Monitoring tells you something changed. We verify whether the number is correct.",
+  },
+  {
+    question: "We already use dbt tests.",
+    answer:
+      "Good, that means you have infrastructure to build on. dbt tests catch surface-level issues: nulls, uniqueness, accepted values, freshness. They do not catch metric definition drift, telemetry gaps, or pipeline logic errors that silently produce wrong numbers. dbt tests verify schema. We verify that the business numbers are actually right.",
+  },
+  {
+    question: "Our numbers look fine.",
+    answer:
+      "Most companies think that until a board question forces someone to reconcile numbers across dashboards. The issues we find do not look like obvious failures. The pipeline runs, the dashboard updates, nothing alerts. But the number is wrong because a join duplicates records, a filter excludes a subset of users, or two services log the same action differently. Typical engagements uncover 5-10 issues, with 1-3 materially affecting decision-making metrics.",
+  },
+  {
+    question: "How long does it take?",
+    answer:
+      "A Diagnostic Sprint takes 1 week and delivers a severity-ranked scorecard of the top issues in your data systems. A Full Engagement takes 4-6 weeks and includes the audit, metric contracts, a dbt project with 40+ tests, interactive dashboards, and drift monitoring. The sprint fee is 100% credited toward a full engagement if you continue.",
+  },
+];
+
+interface FAQAccordionProps {
+  items?: FAQItem[];
+}
+
+export default function FAQAccordion({
+  items = defaultFAQs,
+}: FAQAccordionProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  return (
+    <div className="divide-y divide-bayesiq-200 border-t border-b border-bayesiq-200">
+      {items.map((item, index) => (
+        <div key={index}>
+          <button
+            type="button"
+            className="flex w-full items-center justify-between py-4 text-left text-sm font-medium text-bayesiq-900 transition-colors hover:text-bayesiq-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+            onClick={() => setOpenIndex(openIndex === index ? null : index)}
+            aria-expanded={openIndex === index}
+            aria-controls={`faq-panel-${index}`}
+            id={`faq-button-${index}`}
+          >
+            <span>{item.question}</span>
+            <span
+              className={`ml-4 shrink-0 transition-transform duration-200 ${
+                openIndex === index ? "rotate-45" : ""
+              }`}
+              aria-hidden="true"
+            >
+              +
+            </span>
+          </button>
+          <div
+            id={`faq-panel-${index}`}
+            role="region"
+            aria-labelledby={`faq-button-${index}`}
+            className={`overflow-hidden transition-all duration-200 ${
+              openIndex === index ? "max-h-96 pb-4" : "max-h-0"
+            }`}
+          >
+            <p className="text-sm leading-relaxed text-bayesiq-600">
+              {item.answer}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/consulting/IndustryTabs.tsx
+++ b/src/components/consulting/IndustryTabs.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+/**
+ * Tab bar + content switcher for 4 industry verticals.
+ * Client component (tab state + URL param sync).
+ * Implements WAI-ARIA Tabs pattern with full keyboard navigation.
+ */
+
+import { useState, useRef, useCallback, useEffect, Suspense } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import {
+  verticals,
+  VERTICAL_IDS,
+  DEFAULT_VERTICAL_ID,
+} from "@/lib/industry-data";
+import type { VerticalData } from "@/lib/industry-data";
+import BeforeAfter from "./BeforeAfter";
+
+function resolveVerticalId(param: string | null): string {
+  if (param && VERTICAL_IDS.includes(param)) return param;
+  return DEFAULT_VERTICAL_ID;
+}
+
+function IndustryTabsInner() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  const paramValue = searchParams.get("vertical");
+  const [activeId, setActiveId] = useState(() => resolveVerticalId(paramValue));
+
+  // Sync with URL changes
+  useEffect(() => {
+    setActiveId(resolveVerticalId(searchParams.get("vertical")));
+  }, [searchParams]);
+
+  const selectTab = useCallback(
+    (id: string, focusIndex: number) => {
+      setActiveId(id);
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("vertical", id);
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+      tabRefs.current[focusIndex]?.focus();
+    },
+    [searchParams, router, pathname]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent, currentIndex: number) => {
+      const count = verticals.length;
+      let nextIndex: number | null = null;
+
+      switch (e.key) {
+        case "ArrowRight":
+          nextIndex = (currentIndex + 1) % count;
+          break;
+        case "ArrowLeft":
+          nextIndex = (currentIndex - 1 + count) % count;
+          break;
+        case "Home":
+          nextIndex = 0;
+          break;
+        case "End":
+          nextIndex = count - 1;
+          break;
+        default:
+          return;
+      }
+
+      e.preventDefault();
+      selectTab(verticals[nextIndex].id, nextIndex);
+    },
+    [selectTab]
+  );
+
+  const activeVertical = verticals.find((v) => v.id === activeId) ?? verticals[0];
+  const activeIndex = verticals.findIndex((v) => v.id === activeId);
+
+  return (
+    <div>
+      {/* Tab list */}
+      <div
+        role="tablist"
+        aria-label="Industry verticals"
+        className="flex gap-1 overflow-x-auto border-b border-bayesiq-200"
+      >
+        {verticals.map((vertical, index) => (
+          <button
+            key={vertical.id}
+            id={`tab-${vertical.id}`}
+            role="tab"
+            aria-selected={vertical.id === activeId}
+            aria-controls={`panel-${vertical.id}`}
+            tabIndex={vertical.id === activeId ? 0 : -1}
+            ref={(el) => {
+              tabRefs.current[index] = el;
+            }}
+            onClick={() => selectTab(vertical.id, index)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
+            className={`shrink-0 border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
+              vertical.id === activeId
+                ? "border-bayesiq-900 text-bayesiq-900"
+                : "border-transparent text-bayesiq-500 hover:text-bayesiq-700"
+            }`}
+          >
+            {vertical.displayName}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab panels — all rendered, only active visible */}
+      {verticals.map((vertical, index) => (
+        <div
+          key={vertical.id}
+          id={`panel-${vertical.id}`}
+          role="tabpanel"
+          aria-labelledby={`tab-${vertical.id}`}
+          tabIndex={0}
+          className={vertical.id === activeId ? "" : "hidden"}
+        >
+          <VerticalPanel vertical={vertical} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function VerticalPanel({ vertical }: { vertical: VerticalData }) {
+  return (
+    <div className="space-y-10 py-8">
+      {/* Headline problem */}
+      <p className="text-lg font-medium text-bayesiq-800">
+        {vertical.headline}
+      </p>
+
+      {/* Failure patterns */}
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-bayesiq-400">
+          Common failure patterns
+        </h3>
+        <div className="mt-4 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {vertical.failurePatterns.map((pattern) => (
+            <div key={pattern.title}>
+              <h4 className="text-sm font-semibold text-bayesiq-900">
+                {pattern.title}
+              </h4>
+              <p className="mt-1 text-sm leading-relaxed text-bayesiq-600">
+                {pattern.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Representative finding */}
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-bayesiq-400">
+          Representative finding
+        </h3>
+        <div className="mt-4">
+          <BeforeAfter
+            beforeLabel={vertical.finding.beforeLabel}
+            beforeValue={vertical.finding.beforeValue}
+            afterLabel={vertical.finding.afterLabel}
+            afterValue={vertical.finding.afterValue}
+            annotation={vertical.finding.annotation}
+          />
+        </div>
+      </div>
+
+      {/* Score result */}
+      <div>
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-bayesiq-400">
+          Result
+        </h3>
+        <div className="mt-4 flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-3xl font-bold text-red-600">
+              {vertical.result.scoreBefore}
+            </span>
+            <span className="text-bayesiq-400" aria-hidden="true">
+              &rarr;
+            </span>
+            <span className="font-mono text-3xl font-bold text-green-600">
+              {vertical.result.scoreAfter}
+            </span>
+          </div>
+          <span className="text-xs text-bayesiq-500">Reliability Score</span>
+        </div>
+        <p className="mt-2 text-sm text-bayesiq-600">
+          {vertical.result.summary}
+        </p>
+      </div>
+
+      {/* CTA */}
+      <a
+        href="/contact"
+        className="inline-block rounded-lg bg-bayesiq-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
+      >
+        {vertical.ctaLabel}
+      </a>
+    </div>
+  );
+}
+
+export default function IndustryTabs() {
+  return (
+    <Suspense
+      fallback={
+        <div className="py-8 text-center text-sm text-bayesiq-500">
+          Loading...
+        </div>
+      }
+    >
+      <IndustryTabsInner />
+    </Suspense>
+  );
+}

--- a/src/components/consulting/PipelineSteps.tsx
+++ b/src/components/consulting/PipelineSteps.tsx
@@ -1,0 +1,91 @@
+/**
+ * 6-stage methodology pipeline.
+ * Adapted from /approach page pipeline steps.
+ * Server component.
+ */
+
+interface PipelineStep {
+  number: string;
+  label: string;
+  description: string;
+}
+
+const defaultSteps: PipelineStep[] = [
+  {
+    number: "01",
+    label: "Ingest",
+    description:
+      "Connect to your warehouse and load datasets. Read-only access, no production changes.",
+  },
+  {
+    number: "02",
+    label: "Profile",
+    description:
+      "Scan schemas, column types, null rates, cardinality, and distributions across every table.",
+  },
+  {
+    number: "03",
+    label: "Check",
+    description:
+      "Run 40+ automated quality checks: uniqueness, referential integrity, accepted values, freshness, near-duplicate detection.",
+  },
+  {
+    number: "04",
+    label: "Validate",
+    description:
+      "Recompute KPIs from source data and compare against production dashboards. Flag every metric that diverges.",
+  },
+  {
+    number: "05",
+    label: "Score",
+    description:
+      "Assign a 0-100 reliability score based on check results, weighted by severity and business impact.",
+  },
+  {
+    number: "06",
+    label: "Generate",
+    description:
+      "Produce the audit report, dbt project, metric contracts, and interactive dashboards from validated data.",
+  },
+];
+
+interface PipelineStepsProps {
+  steps?: PipelineStep[];
+}
+
+export default function PipelineSteps({
+  steps = defaultSteps,
+}: PipelineStepsProps) {
+  return (
+    <div className="relative">
+      {/* Connector line */}
+      <div
+        className="absolute left-5 top-0 hidden h-full w-px bg-bayesiq-200 md:block"
+        aria-hidden="true"
+      />
+      <ol className="space-y-8">
+        {steps.map((step) => (
+          <li key={step.number} className="relative md:pl-14">
+            {/* Step number circle */}
+            <div className="mb-2 flex items-center gap-3 md:absolute md:left-0 md:top-0 md:mb-0">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-bayesiq-900 font-mono text-sm font-medium text-white">
+                {step.number}
+              </span>
+              <h3 className="font-display text-lg font-semibold text-bayesiq-900 md:hidden">
+                {step.label}
+              </h3>
+            </div>
+            <div>
+              <h3 className="hidden font-display text-lg font-semibold text-bayesiq-900 md:block">
+                {step.label}
+              </h3>
+              <p className="mt-1 text-sm leading-relaxed text-bayesiq-600">
+                {step.description}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/src/components/consulting/__tests__/BeforeAfter.test.tsx
+++ b/src/components/consulting/__tests__/BeforeAfter.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import BeforeAfter from "../BeforeAfter";
+
+describe("BeforeAfter", () => {
+  it("renders before and after values with labels", () => {
+    render(
+      <BeforeAfter
+        beforeLabel="Reported"
+        beforeValue="$1.2M"
+        afterLabel="Actual"
+        afterValue="$960K"
+      />
+    );
+    expect(screen.getByText("Reported")).toBeInTheDocument();
+    expect(screen.getByText("$1.2M")).toBeInTheDocument();
+    expect(screen.getByText("Actual")).toBeInTheDocument();
+    expect(screen.getByText("$960K")).toBeInTheDocument();
+  });
+
+  it("renders annotation when provided", () => {
+    render(
+      <BeforeAfter
+        beforeLabel="Before"
+        beforeValue="100"
+        afterLabel="After"
+        afterValue="50"
+        annotation="50% reduction found."
+      />
+    );
+    expect(screen.getByText("50% reduction found.")).toBeInTheDocument();
+  });
+
+  it("does not render annotation when not provided", () => {
+    const { container } = render(
+      <BeforeAfter
+        beforeLabel="Before"
+        beforeValue="100"
+        afterLabel="After"
+        afterValue="50"
+      />
+    );
+    // Only the grid and its children, no annotation paragraph
+    const paragraphs = container.querySelectorAll("p");
+    // 4 paragraphs: before label, before value, after label, after value
+    expect(paragraphs).toHaveLength(4);
+  });
+});

--- a/src/components/consulting/__tests__/BentoGrid.test.tsx
+++ b/src/components/consulting/__tests__/BentoGrid.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import BentoGrid from "../BentoGrid";
+import BentoCard from "../BentoCard";
+
+describe("BentoGrid + BentoCard", () => {
+  it("renders the correct number of cards", () => {
+    render(
+      <BentoGrid>
+        <BentoCard title="Card A" description="Desc A" />
+        <BentoCard title="Card B" description="Desc B" />
+        <BentoCard title="Card C" description="Desc C" span={2} />
+      </BentoGrid>
+    );
+    expect(screen.getByText("Card A")).toBeInTheDocument();
+    expect(screen.getByText("Card B")).toBeInTheDocument();
+    expect(screen.getByText("Card C")).toBeInTheDocument();
+  });
+
+  it("applies span-2 CSS class for large cards", () => {
+    const { container } = render(
+      <BentoGrid>
+        <BentoCard title="Small" description="desc" span={1} />
+        <BentoCard title="Large" description="desc" span={2} />
+      </BentoGrid>
+    );
+    const largeCard = screen.getByText("Large").closest("div");
+    expect(largeCard?.className).toContain("sm:col-span-2");
+
+    const smallCard = screen.getByText("Small").closest("div");
+    expect(smallCard?.className).not.toContain("sm:col-span-2");
+  });
+});

--- a/src/components/consulting/__tests__/EngagementTiers.test.tsx
+++ b/src/components/consulting/__tests__/EngagementTiers.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import EngagementTiers from "../EngagementTiers";
+
+describe("EngagementTiers", () => {
+  it("renders 3 tier cards", () => {
+    render(<EngagementTiers />);
+    expect(screen.getByText("Diagnostic Sprint")).toBeInTheDocument();
+    expect(screen.getByText("Full Engagement")).toBeInTheDocument();
+    expect(screen.getByText("Continuous Monitoring")).toBeInTheDocument();
+  });
+
+  it("renders timelines", () => {
+    render(<EngagementTiers />);
+    expect(screen.getByText("1 week")).toBeInTheDocument();
+    expect(screen.getByText("4-6 weeks")).toBeInTheDocument();
+    expect(screen.getByText("Ongoing")).toBeInTheDocument();
+  });
+
+  it("contains NO dollar amounts anywhere in the output", () => {
+    const { container } = render(<EngagementTiers />);
+    const text = container.textContent || "";
+    expect(text).not.toMatch(/\$\d/);
+    expect(text).not.toMatch(/K per/i);
+    expect(text).not.toMatch(/\/month/i);
+  });
+
+  it("highlights the Full Engagement tier", () => {
+    render(<EngagementTiers />);
+    expect(screen.getByText("Most Popular")).toBeInTheDocument();
+  });
+});

--- a/src/components/consulting/__tests__/FAQAccordion.test.tsx
+++ b/src/components/consulting/__tests__/FAQAccordion.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import userEvent from "@testing-library/user-event";
+import FAQAccordion from "../FAQAccordion";
+
+describe("FAQAccordion", () => {
+  it("renders all 6 default questions", () => {
+    render(<FAQAccordion />);
+    expect(
+      screen.getByText("Can't our team do this ourselves?")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("What data access do you need?")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "How is this different from Monte Carlo or Great Expectations?"
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("We already use dbt tests.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Our numbers look fine.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("How long does it take?")
+    ).toBeInTheDocument();
+  });
+
+  it("clicking a question expands its answer", async () => {
+    const user = userEvent.setup();
+    render(<FAQAccordion />);
+
+    const button = screen.getByText("How long does it take?");
+    await user.click(button);
+
+    expect(button.closest("button")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("clicking another question collapses the first", async () => {
+    const user = userEvent.setup();
+    render(<FAQAccordion />);
+
+    const first = screen.getByText("Can't our team do this ourselves?");
+    const second = screen.getByText("What data access do you need?");
+
+    await user.click(first);
+    expect(first.closest("button")).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(second);
+    expect(first.closest("button")).toHaveAttribute("aria-expanded", "false");
+    expect(second.closest("button")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("accepts custom items", () => {
+    render(
+      <FAQAccordion
+        items={[{ question: "Custom Q?", answer: "Custom A." }]}
+      />
+    );
+    expect(screen.getByText("Custom Q?")).toBeInTheDocument();
+  });
+});

--- a/src/components/consulting/__tests__/IndustryTabs.test.tsx
+++ b/src/components/consulting/__tests__/IndustryTabs.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import userEvent from "@testing-library/user-event";
+
+// Mock Next.js navigation hooks
+const mockReplace = vi.fn();
+const mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => "/consulting/industries",
+}));
+
+import IndustryTabs from "../IndustryTabs";
+
+describe("IndustryTabs", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    // Reset search params to empty
+    mockSearchParams.delete("vertical");
+  });
+
+  it("renders 4 tab buttons", () => {
+    render(<IndustryTabs />);
+    expect(screen.getByRole("tab", { name: "Fintech" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Healthcare" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "SaaS" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Real Estate" })).toBeInTheDocument();
+  });
+
+  it("defaults to Fintech tab active", () => {
+    render(<IndustryTabs />);
+    const fintechTab = screen.getByRole("tab", { name: "Fintech" });
+    expect(fintechTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("clicking Healthcare tab shows healthcare content", async () => {
+    const user = userEvent.setup();
+    render(<IndustryTabs />);
+
+    await user.click(screen.getByRole("tab", { name: "Healthcare" }));
+
+    const healthcareTab = screen.getByRole("tab", { name: "Healthcare" });
+    expect(healthcareTab).toHaveAttribute("aria-selected", "true");
+
+    // Healthcare failure pattern should be visible
+    expect(
+      screen.getByText("Clinical metrics don't reconcile")
+    ).toBeInTheDocument();
+  });
+
+  it("has correct ARIA attributes", () => {
+    render(<IndustryTabs />);
+
+    const tablist = screen.getByRole("tablist");
+    expect(tablist).toHaveAttribute("aria-label", "Industry verticals");
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(4);
+
+    // Each tab should have aria-controls pointing to a panel
+    for (const tab of tabs) {
+      const panelId = tab.getAttribute("aria-controls");
+      expect(panelId).toBeTruthy();
+      expect(document.getElementById(panelId!)).toBeInTheDocument();
+    }
+
+    // Each panel should have aria-labelledby pointing back to the tab
+    const panels = screen.getAllByRole("tabpanel");
+    // Only the visible panel is in the DOM as a tabpanel (hidden panels have display:none)
+    expect(panels.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders BeforeAfter with monospace-styled numbers in each tab", async () => {
+    const user = userEvent.setup();
+    render(<IndustryTabs />);
+
+    // Fintech finding value
+    expect(screen.getByText("$1.2M")).toBeInTheDocument();
+
+    // Switch to Healthcare
+    await user.click(screen.getByRole("tab", { name: "Healthcare" }));
+    expect(screen.getByText("14.2%")).toBeInTheDocument();
+  });
+});

--- a/src/components/consulting/__tests__/NoPricing.test.tsx
+++ b/src/components/consulting/__tests__/NoPricing.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import EngagementTiers from "../EngagementTiers";
+import FAQAccordion from "../FAQAccordion";
+
+describe("No-pricing assertion", () => {
+  it("EngagementTiers contains no dollar amounts", () => {
+    const { container } = render(<EngagementTiers />);
+    const text = container.textContent || "";
+    expect(text).not.toMatch(/\$\d/);
+  });
+
+  it("FAQAccordion contains no dollar amounts in questions", () => {
+    const { container } = render(<FAQAccordion />);
+    // Get all button text (the questions)
+    const buttons = container.querySelectorAll("button");
+    for (const button of buttons) {
+      expect(button.textContent).not.toMatch(/\$\d/);
+    }
+  });
+
+  it("EngagementTiers contains no price-like patterns", () => {
+    const { container } = render(<EngagementTiers />);
+    const text = container.textContent || "";
+    expect(text).not.toMatch(/K per/i);
+    expect(text).not.toMatch(/\/month/i);
+    expect(text).not.toMatch(/\$[\d,]+/);
+  });
+});

--- a/src/components/consulting/__tests__/PipelineSteps.test.tsx
+++ b/src/components/consulting/__tests__/PipelineSteps.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import PipelineSteps from "../PipelineSteps";
+
+describe("PipelineSteps", () => {
+  it("renders all 6 default steps", () => {
+    render(<PipelineSteps />);
+    const labels = ["Ingest", "Profile", "Check", "Validate", "Score", "Generate"];
+    for (const label of labels) {
+      expect(screen.getAllByText(label).length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("renders step numbers 01-06", () => {
+    render(<PipelineSteps />);
+    for (const num of ["01", "02", "03", "04", "05", "06"]) {
+      expect(screen.getByText(num)).toBeInTheDocument();
+    }
+  });
+
+  it("accepts custom steps", () => {
+    render(
+      <PipelineSteps
+        steps={[
+          { number: "01", label: "CustomStep", description: "A custom step" },
+        ]}
+      />
+    );
+    expect(screen.getAllByText("CustomStep").length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/lib/__tests__/industry-data.test.ts
+++ b/src/lib/__tests__/industry-data.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  verticals,
+  getVerticalById,
+  VERTICAL_IDS,
+  DEFAULT_VERTICAL_ID,
+} from "../industry-data";
+
+describe("industry-data", () => {
+  it("exports exactly 4 verticals", () => {
+    expect(verticals).toHaveLength(4);
+  });
+
+  it("has the correct vertical IDs", () => {
+    expect(VERTICAL_IDS).toEqual(["fintech", "healthcare", "saas", "real_estate"]);
+  });
+
+  it("defaults to fintech", () => {
+    expect(DEFAULT_VERTICAL_ID).toBe("fintech");
+  });
+
+  it("each vertical has at least 2 failure patterns", () => {
+    for (const v of verticals) {
+      expect(v.failurePatterns.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("each vertical has a finding with before/after values", () => {
+    for (const v of verticals) {
+      expect(v.finding.beforeLabel).toBeTruthy();
+      expect(v.finding.beforeValue).toBeTruthy();
+      expect(v.finding.afterLabel).toBeTruthy();
+      expect(v.finding.afterValue).toBeTruthy();
+    }
+  });
+
+  it("each vertical has a CTA label", () => {
+    for (const v of verticals) {
+      expect(v.ctaLabel).toBeTruthy();
+    }
+  });
+
+  it("getVerticalById returns correct vertical", () => {
+    const fintech = getVerticalById("fintech");
+    expect(fintech?.displayName).toBe("Fintech");
+  });
+
+  it("getVerticalById returns undefined for unknown ID", () => {
+    expect(getVerticalById("bogus")).toBeUndefined();
+  });
+
+  it("no vertical content contains engagement pricing patterns", () => {
+    // Guards against accidentally adding engagement/tier pricing to industry data.
+    // Dollar amounts that are *finding values* (e.g., "$340K revenue discrepancy") are fine.
+    // What we block: pricing tiers like "$15K", "$25K", "$4,500", "/month", "K per".
+    for (const v of verticals) {
+      const allText = [
+        v.headline,
+        ...v.failurePatterns.map((fp) => fp.description),
+      ].join(" ");
+      expect(allText).not.toMatch(/\$[\d,]+K?\s*(per|\/month)/i);
+      expect(allText).not.toMatch(/\/month/i);
+    }
+  });
+});

--- a/src/lib/industry-data.ts
+++ b/src/lib/industry-data.ts
@@ -1,0 +1,204 @@
+/**
+ * Industry vertical content data for the consulting/industries page.
+ *
+ * Content sources:
+ * - Fintech: migrated from /fintech/page.tsx (problems array, case study callout)
+ * - Healthcare: migrated from /healthcare/page.tsx (failurePatterns array, case study callout)
+ * - SaaS: new content derived from golden flow vertical_narrative.json + domain patterns
+ * - Real Estate: new content derived from golden flow vertical_narrative.json + domain patterns
+ */
+
+export interface FailurePattern {
+  title: string;
+  description: string;
+}
+
+export interface Finding {
+  beforeLabel: string;
+  beforeValue: string;
+  afterLabel: string;
+  afterValue: string;
+  annotation: string;
+}
+
+export interface VerticalResult {
+  scoreBefore: number;
+  scoreAfter: number;
+  summary: string;
+}
+
+export interface VerticalData {
+  id: string;
+  displayName: string;
+  headline: string;
+  failurePatterns: FailurePattern[];
+  finding: Finding;
+  result: VerticalResult;
+  ctaLabel: string;
+}
+
+export const verticals: VerticalData[] = [
+  {
+    id: "fintech",
+    displayName: "Fintech",
+    headline:
+      "Revenue metrics built on transaction pipelines that nobody has audited end-to-end.",
+    failurePatterns: [
+      {
+        title: "Revenue metrics that don't match finance",
+        description:
+          "Product analytics show one revenue number. Finance shows another. Metric validation recomputes KPIs from raw transaction data to show exactly where currency conversion logic, refund handling, or phantom events introduce the gap.",
+      },
+      {
+        title: "Payment event telemetry with gaps",
+        description:
+          "Transaction events fire from multiple clients and payment processors. Required fields like currency, payment_method, or transaction_id are null 5-20% of the time. Schema profiling catches null spikes before they reach downstream aggregations.",
+      },
+      {
+        title: "Compliance reporting on unaudited pipelines",
+        description:
+          "SAR filing counts, transaction monitoring volumes, and KYC completion rates are built from the same pipelines as product dashboards. A scored audit with severity-ranked findings shows exactly which pipeline issues affect compliance numbers.",
+      },
+    ],
+    finding: {
+      beforeLabel: "Reported Revenue",
+      beforeValue: "$1.2M",
+      afterLabel: "Actual Revenue",
+      afterValue: "$960K",
+      annotation:
+        "$240K overstatement found. 1,200 dropped transaction records and a fee calculation error in the settlement pipeline.",
+    },
+    result: {
+      scoreBefore: 52,
+      scoreAfter: 84,
+      summary:
+        "A mid-market payments processor found a $340K annual revenue discrepancy and 1,200 silently dropped transaction records.",
+    },
+    ctaLabel: "Book a Fintech Diagnostic",
+  },
+  {
+    id: "healthcare",
+    displayName: "Healthcare",
+    headline:
+      "Clinical metrics are only as good as the data pipeline behind them.",
+    failurePatterns: [
+      {
+        title: "Clinical metrics don't reconcile",
+        description:
+          "EMR data says one thing, the analytics dashboard says another. Readmission rates, patient volume, and outcome metrics diverge across systems. Metric validation compares source-system figures against downstream calculations to show exactly where numbers split.",
+      },
+      {
+        title: "Regulatory reporting built on unvalidated data",
+        description:
+          "Quality measures for CMS, Joint Commission, or payer contracts are computed from pipelines nobody has audited. A scored audit catches data completeness issues, schema drift, and transformation errors before they reach a regulatory submission.",
+      },
+      {
+        title: "Telemetry gaps in patient-facing tools",
+        description:
+          "Patient portals, scheduling apps, and telehealth platforms emit events, but required fields are missing, sessions are not stitched, and engagement metrics are unreliable. Schema profiling detects null rates, field coverage gaps, and type inconsistencies.",
+      },
+    ],
+    finding: {
+      beforeLabel: "Reported Readmission Rate",
+      beforeValue: "14.2%",
+      afterLabel: "Actual Readmission Rate",
+      afterValue: "11.8%",
+      annotation:
+        "340 patients double-counted due to inconsistent patient ID formatting across clinics.",
+    },
+    result: {
+      scoreBefore: 44,
+      scoreAfter: 82,
+      summary:
+        "A regional health system found 340 patients double-counted in readmission metrics. The corrected rate changed resource allocation decisions.",
+    },
+    ctaLabel: "Book a Healthcare Diagnostic",
+  },
+  {
+    id: "saas",
+    displayName: "SaaS",
+    headline:
+      "Product analytics with schema drift, KPI reconciliation failures, and experiments on corrupted baselines.",
+    failurePatterns: [
+      {
+        title: "Event definitions change without pipeline updates",
+        description:
+          "Product ships a new feature, the event schema changes, but the analytics pipeline still expects the old format. Metrics silently degrade as nulls accumulate in fields that used to be populated. Schema profiling catches these drift patterns within days, not months.",
+      },
+      {
+        title: "KPI reconciliation failures across teams",
+        description:
+          "MRR computed differently by product, finance, and investor dashboards. Each team applies different filters, different date boundaries, different refund logic. Metric validation recomputes each KPI from source data against every downstream consumer.",
+      },
+      {
+        title: "A/B test results on corrupted baselines",
+        description:
+          "Duplicate events, identity stitching gaps across web and mobile, and inconsistent funnel definitions mean experiment results are measured on baselines that do not represent reality. Quality checks catch near-duplicates and event inflation before they corrupt experiments.",
+      },
+    ],
+    finding: {
+      beforeLabel: "Reported Churn Rate",
+      beforeValue: "8.4%",
+      afterLabel: "Actual Churn Rate",
+      afterValue: "6.5%",
+      annotation:
+        "22% churn overstatement caused by duplicate cancellation events and inconsistent subscription status logic.",
+    },
+    result: {
+      scoreBefore: 38,
+      scoreAfter: 87,
+      summary:
+        "A Series B SaaS company discovered their churn metric was overstated by 22%, changing the narrative for their next fundraise.",
+    },
+    ctaLabel: "Book a SaaS Diagnostic",
+  },
+  {
+    id: "real_estate",
+    displayName: "Real Estate",
+    headline:
+      "Portfolio metrics with inconsistent property classification and collection rate overstatement.",
+    failurePatterns: [
+      {
+        title: "Collection rate overstatement masking uncollected rent",
+        description:
+          "Reported collection rates include pre-payments and exclude write-offs inconsistently. A 10%+ overstatement masks hundreds of thousands in uncollected rent, directly impacting LP distributions and investor confidence.",
+      },
+      {
+        title: "Occupancy calculations with double-counted units",
+        description:
+          "Units classified differently across property management systems and reporting layers. Some units are counted as occupied in one system and vacant in another. Vacancy reporting gaps compound across large portfolios.",
+      },
+      {
+        title: "Inconsistent property classification across systems",
+        description:
+          "The same property is categorized differently in the PMS, accounting system, and investor reports. NOI aggregations, cap rate calculations, and portfolio-level metrics inherit these inconsistencies silently.",
+      },
+    ],
+    finding: {
+      beforeLabel: "Reported Vacancy Loss",
+      beforeValue: "5.1%",
+      afterLabel: "Actual Vacancy Loss",
+      afterValue: "0.0%",
+      annotation:
+        "100% discrepancy in vacancy loss calculation. Reported value was a phantom metric not grounded in raw lease data.",
+    },
+    result: {
+      scoreBefore: 43,
+      scoreAfter: 65,
+      summary:
+        "A real estate portfolio manager found 10%+ collection overstatement masking uncollected rent across 12 properties.",
+    },
+    ctaLabel: "Book a Real Estate Diagnostic",
+  },
+];
+
+/** Look up a vertical by its ID. Returns undefined for unknown IDs. */
+export function getVerticalById(id: string): VerticalData | undefined {
+  return verticals.find((v) => v.id === id);
+}
+
+/** All valid vertical IDs. */
+export const VERTICAL_IDS = verticals.map((v) => v.id);
+
+/** Default vertical when no valid selection is provided. */
+export const DEFAULT_VERTICAL_ID = "fintech";


### PR DESCRIPTION
## Summary
- /consulting: methodology pipeline, engagement tiers (no pricing), deliverables bento grid, FAQ accordion
- /consulting/industries: 4-vertical tabbed page (Fintech, Healthcare, SaaS, Real Estate)
- Full WAI-ARIA keyboard navigation on tabs
- Content migrated from /fintech, /healthcare, sales repo
- JetBrains Mono for all numerical values
- No pricing enforced by automated tests

## Test plan
- [x] npm run build passes
- [x] 110 tests pass (24 new)

issue: null