### PR TITLE
Rewrite 05: Case studies + sample report uplift

### DIFF
--- a/src/app/consulting/__tests__/case-studies.test.tsx
+++ b/src/app/consulting/__tests__/case-studies.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import CaseStudiesPage from "../case-studies/page";
+
+// Mock framer-motion
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+    }: {
+      children: React.ReactNode;
+      className?: string;
+    }) => <div className={className}>{children}</div>,
+  },
+  useInView: vi.fn(() => true),
+  animate: vi.fn((_from, _to, options) => {
+    if (options?.onUpdate) options.onUpdate(_to);
+    return { stop: vi.fn() };
+  }),
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+describe("CaseStudiesPage", () => {
+  it("renders all 3 visible case study slugs", () => {
+    const { container } = render(<CaseStudiesPage />);
+    expect(container.querySelector("#saas")).toBeTruthy();
+    expect(container.querySelector("#fintech")).toBeTruthy();
+    expect(container.querySelector("#healthcare")).toBeTruthy();
+  });
+
+  it("does not render the hidden Shuk placeholder", () => {
+    const { container } = render(<CaseStudiesPage />);
+    expect(container.querySelector("#shuk")).toBeNull();
+    expect(screen.queryByText("Real Estate")).toBeNull();
+  });
+
+  it("renders industry headings for all 3 studies", () => {
+    render(<CaseStudiesPage />);
+    expect(
+      screen.getByText("SaaS — Product Analytics")
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Fintech — Transaction Pipeline")
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Healthcare — Clinical Analytics")
+    ).toBeTruthy();
+  });
+
+  it("links to /consulting/sample-report (not /sample-report)", () => {
+    const { container } = render(<CaseStudiesPage />);
+    const sampleReportLinks = container.querySelectorAll(
+      'a[href="/consulting/sample-report"]'
+    );
+    expect(sampleReportLinks.length).toBeGreaterThan(0);
+    // Should NOT link to old route
+    const oldLinks = container.querySelectorAll('a[href="/sample-report"]');
+    expect(oldLinks.length).toBe(0);
+  });
+
+  it("links to /consulting/explore as tertiary CTA", () => {
+    const { container } = render(<CaseStudiesPage />);
+    const exploreLinks = container.querySelectorAll(
+      'a[href="/consulting/explore"]'
+    );
+    expect(exploreLinks.length).toBeGreaterThan(0);
+  });
+
+  it("does not reference stale routes", () => {
+    const { container } = render(<CaseStudiesPage />);
+    const html = container.innerHTML;
+    expect(html).not.toContain('href="/services"');
+    expect(html).not.toContain('href="/case-studies"');
+  });
+});

--- a/src/app/consulting/__tests__/sample-report.test.tsx
+++ b/src/app/consulting/__tests__/sample-report.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import SampleReportPage from "../sample-report/page";
+
+// Mock framer-motion
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+    }: {
+      children: React.ReactNode;
+      className?: string;
+    }) => <div className={className}>{children}</div>,
+  },
+  useInView: vi.fn(() => true),
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+describe("SampleReportPage", () => {
+  it("renders all 8 artifacts", () => {
+    render(<SampleReportPage />);
+    const artifactFiles = [
+      "audit_report.md",
+      "dataset_profile.json",
+      "quality_checks.json",
+      "ASSUMPTIONS.md",
+      "METRICS.md",
+      "dbt project",
+      "Streamlit dashboard",
+      "canonicalization_mapping.json",
+    ];
+    for (const file of artifactFiles) {
+      const matches = screen.getAllByText(file);
+      expect(matches.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("renders all 6 findings", () => {
+    render(<SampleReportPage />);
+    for (const id of ["F-01", "F-02", "F-03", "F-04", "F-05", "F-06"]) {
+      expect(screen.getByText(id)).toBeTruthy();
+    }
+  });
+
+  it("renders scoring rubric table", () => {
+    render(<SampleReportPage />);
+    expect(screen.getByText("Strong")).toBeTruthy();
+    expect(screen.getByText("Needs Work")).toBeTruthy();
+    expect(screen.getByText("At Risk")).toBeTruthy();
+  });
+
+  it("renders severity definitions", () => {
+    render(<SampleReportPage />);
+    // Severity levels should appear in the definitions table
+    const criticalElements = screen.getAllByText("Critical");
+    expect(criticalElements.length).toBeGreaterThanOrEqual(2); // In findings + definitions
+  });
+
+  it("links to /consulting/case-studies (not /case-studies)", () => {
+    const { container } = render(<SampleReportPage />);
+    const caseStudyLinks = container.querySelectorAll(
+      'a[href="/consulting/case-studies"]'
+    );
+    expect(caseStudyLinks.length).toBeGreaterThan(0);
+  });
+
+  it("links to /consulting/explore as tertiary CTA", () => {
+    const { container } = render(<SampleReportPage />);
+    const exploreLinks = container.querySelectorAll(
+      'a[href="/consulting/explore"]'
+    );
+    expect(exploreLinks.length).toBeGreaterThan(0);
+  });
+
+  it("does not reference stale routes", () => {
+    const { container } = render(<SampleReportPage />);
+    const html = container.innerHTML;
+    expect(html).not.toContain('href="/services"');
+    expect(html).not.toContain('href="/platform"');
+    // /sample-report without /consulting prefix should not be linked
+    const oldLinks = container.querySelectorAll('a[href="/sample-report"]');
+    expect(oldLinks.length).toBe(0);
+  });
+
+  it("uses InlineEvidence (font-mono code elements) for artifact file names", () => {
+    const { container } = render(<SampleReportPage />);
+    const codeElements = container.querySelectorAll("code.font-mono");
+    // At minimum: 8 artifact names + 6 finding IDs + 1 in heading
+    expect(codeElements.length).toBeGreaterThanOrEqual(15);
+  });
+});

--- a/src/app/consulting/case-studies/page.tsx
+++ b/src/app/consulting/case-studies/page.tsx
@@ -1,15 +1,20 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import CTA from "@/components/CTA";
+import AnimatedCounter from "@/components/AnimatedCounter";
+import BeforeAfterSplit from "@/components/BeforeAfterSplit";
+import InlineEvidence from "@/components/InlineEvidence";
+import SectionReveal from "@/components/SectionReveal";
 
 export const metadata: Metadata = {
-  title: "Case Studies — BayesIQ",
+  title: "Case Studies",
   description:
     "Representative engagements showing how BayesIQ finds broken metrics, validates pipelines, and delivers scored audit reports — across SaaS, Fintech, and Healthcare.",
   openGraph: {
     title: "Case Studies — BayesIQ",
     description:
       "Representative engagements showing how BayesIQ finds broken metrics, validates pipelines, and delivers scored audit reports — across SaaS, Fintech, and Healthcare.",
+    url: "/consulting/case-studies",
   },
 };
 
@@ -29,6 +34,7 @@ interface CaseStudy {
   timeline: string;
   keyStats: string[];
   ctaText: string;
+  hidden?: boolean;
 }
 
 const caseStudies: CaseStudy[] = [
@@ -140,7 +146,28 @@ const caseStudies: CaseStudy[] = [
     ],
     ctaText: "Audit Your Clinical Data",
   },
+  // Shuk placeholder — structurally ready, not rendered until post-contract
+  {
+    industry: "Real Estate — Property Management",
+    slug: "shuk",
+    hidden: true,
+    context: "",
+    brokenState: "",
+    findings: [],
+    impact: "",
+    remediation: "",
+    deliverables: [],
+    score: 0,
+    severity: "",
+    resultScore: 0,
+    tier: "",
+    timeline: "",
+    keyStats: [],
+    ctaText: "",
+  },
 ];
+
+const visibleCaseStudies = caseStudies.filter((s) => !s.hidden);
 
 const caseStudiesJsonLd = {
   "@context": "https://schema.org",
@@ -155,16 +182,6 @@ const caseStudiesJsonLd = {
   },
 };
 
-function scoreBadgeClasses(score: number): string {
-  if (score < 50) {
-    return "bg-red-500/10 text-red-700 border-red-200";
-  }
-  if (score < 70) {
-    return "bg-orange-500/10 text-orange-700 border-orange-200";
-  }
-  return "bg-yellow-500/10 text-yellow-700 border-yellow-200";
-}
-
 export default function CaseStudiesPage() {
   return (
     <>
@@ -173,148 +190,171 @@ export default function CaseStudiesPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(caseStudiesJsonLd) }}
       />
 
+      {/* Hero */}
       <section className="px-6 py-24">
         <div className="mx-auto max-w-5xl">
-          <h1 className="text-4xl font-bold tracking-tight text-bayesiq-900">
-            Case Studies
-          </h1>
-          <p className="mt-4 text-lg text-bayesiq-600">
-            Representative engagements based on real patterns we see across
-            industries. Details are composites — your audit uses your actual
-            data.
-          </p>
+          <SectionReveal>
+            <h1 className="text-4xl font-bold tracking-tight text-bayesiq-900">
+              Case Studies
+            </h1>
+            <p className="mt-4 text-lg text-bayesiq-600">
+              Representative engagements based on real patterns we see across
+              industries. Details are composites — your audit uses your actual
+              data.
+            </p>
 
-          <div className="mt-6 flex gap-4">
-            {caseStudies.map((s) => (
-              <a
-                key={s.slug}
-                href={`#${s.slug}`}
-                className="text-sm font-medium text-bayesiq-600 hover:text-bayesiq-900"
-              >
-                {s.industry.split(" — ")[0]}
-              </a>
-            ))}
-          </div>
+            <div className="mt-6 flex gap-4">
+              {visibleCaseStudies.map((s) => (
+                <a
+                  key={s.slug}
+                  href={`#${s.slug}`}
+                  className="text-sm font-medium text-bayesiq-600 hover:text-bayesiq-900"
+                >
+                  {s.industry.split(" — ")[0]}
+                </a>
+              ))}
+            </div>
+          </SectionReveal>
         </div>
       </section>
 
+      {/* Case Studies */}
       <section className="px-6 pb-20">
         <div className="mx-auto max-w-5xl space-y-16">
-          {caseStudies.map((study) => (
-            <article
-              key={study.slug}
-              id={study.slug}
-              className="rounded-2xl border border-bayesiq-200 bg-white p-8 shadow-sm"
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <h2 className="text-2xl font-bold text-bayesiq-900">
-                    {study.industry}
-                  </h2>
-                  <p className="mt-1 text-sm text-bayesiq-500">
-                    {study.tier} · {study.timeline}
-                  </p>
+          {visibleCaseStudies.map((study) => (
+            <SectionReveal key={study.slug}>
+              <article
+                id={study.slug}
+                className="rounded-2xl border border-bayesiq-200 bg-white p-8 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h2 className="text-2xl font-bold text-bayesiq-900">
+                      {study.industry}
+                    </h2>
+                    <p className="mt-1 text-sm text-bayesiq-500">
+                      <InlineEvidence>{study.tier}</InlineEvidence>
+                      <span className="mx-2">·</span>
+                      {study.timeline}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1 rounded-lg border border-bayesiq-200 bg-bayesiq-50 px-3 py-1.5 text-sm font-semibold text-bayesiq-700">
+                    <AnimatedCounter
+                      from={study.score}
+                      to={study.score}
+                      className="font-mono"
+                    />
+                    <span className="mx-1 text-bayesiq-400">&rarr;</span>
+                    <AnimatedCounter
+                      from={study.score}
+                      to={study.resultScore}
+                      className="font-mono text-green-700"
+                    />
+                  </div>
                 </div>
-                <span
-                  className={`inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-sm font-semibold ${scoreBadgeClasses(study.score)}`}
-                >
-                  {study.score} → {study.resultScore}
-                  <span className="text-xs font-normal">
-                    ({study.severity})
-                  </span>
-                </span>
-              </div>
 
-              <div className="mt-4 flex flex-wrap gap-4">
-                {study.keyStats.map((stat) => (
-                  <span
-                    key={stat}
-                    className="rounded-full bg-bayesiq-100 px-3 py-1 text-sm font-medium text-bayesiq-700"
+                {/* Before/After Split */}
+                <div className="mt-6">
+                  <BeforeAfterSplit
+                    before={{
+                      label: "Before Audit",
+                      score: study.score,
+                      severity: study.severity,
+                      details: study.brokenState,
+                    }}
+                    after={{
+                      label: "After Remediation",
+                      score: study.resultScore,
+                      tier: study.tier,
+                      details: study.remediation,
+                    }}
+                  />
+                </div>
+
+                {/* Key Stats */}
+                <div className="mt-6 flex flex-wrap gap-4">
+                  {study.keyStats.map((stat) => (
+                    <span
+                      key={stat}
+                      className="rounded-full bg-bayesiq-100 px-3 py-1 text-sm font-medium text-bayesiq-700"
+                    >
+                      {stat}
+                    </span>
+                  ))}
+                </div>
+
+                <div className="mt-6 space-y-6">
+                  <div>
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-bayesiq-500">
+                      Client Context
+                    </h3>
+                    <p className="mt-1 text-bayesiq-700">{study.context}</p>
+                  </div>
+
+                  <div>
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-bayesiq-500">
+                      What BayesIQ Found
+                    </h3>
+                    <ul className="mt-1 space-y-1">
+                      {study.findings.map((finding, j) => (
+                        <li
+                          key={j}
+                          className="flex items-start gap-2 text-bayesiq-700"
+                        >
+                          <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-bayesiq-400" />
+                          {finding}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <div>
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-bayesiq-500">
+                      Business Impact
+                    </h3>
+                    <p className="mt-1 text-bayesiq-700">{study.impact}</p>
+                  </div>
+
+                  <div>
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-bayesiq-500">
+                      Deliverables
+                    </h3>
+                    <ul className="mt-1 space-y-1">
+                      {study.deliverables.map((d, j) => (
+                        <li
+                          key={j}
+                          className="flex items-start gap-2 text-bayesiq-700"
+                        >
+                          <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-bayesiq-400" />
+                          {d}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+
+                <div className="mt-8 flex flex-wrap gap-3">
+                  <Link
+                    href="/contact"
+                    className="rounded-lg bg-bayesiq-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
                   >
-                    {stat}
-                  </span>
-                ))}
-              </div>
-
-              <div className="mt-6 space-y-6">
-                <div>
-                  <h3 className="text-sm font-semibold uppercase tracking-wide text-bayesiq-500">
-                    Client Context
-                  </h3>
-                  <p className="mt-1 text-bayesiq-700">{study.context}</p>
+                    {study.ctaText}
+                  </Link>
+                  <Link
+                    href="/consulting/sample-report"
+                    className="rounded-lg border border-bayesiq-300 px-4 py-2 text-sm font-medium text-bayesiq-700 transition-colors hover:bg-bayesiq-50"
+                  >
+                    See a Sample Report
+                  </Link>
+                  <Link
+                    href="/consulting/explore"
+                    className="px-4 py-2 text-sm font-medium text-bayesiq-500 transition-colors hover:text-bayesiq-700"
+                  >
+                    Explore a live engagement &rarr;
+                  </Link>
                 </div>
-
-                <div>
-                  <h3 className="text-sm font-semibold uppercase tracking-wide text-bayesiq-500">
-                    What Was Broken
-                  </h3>
-                  <p className="mt-1 text-bayesiq-700">{study.brokenState}</p>
-                </div>
-
-                <div>
-                  <h3 className="text-sm font-semibold uppercase tracking-wide text-bayesiq-500">
-                    What BayesIQ Found
-                  </h3>
-                  <ul className="mt-1 space-y-1">
-                    {study.findings.map((finding, j) => (
-                      <li
-                        key={j}
-                        className="flex items-start gap-2 text-bayesiq-700"
-                      >
-                        <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-bayesiq-400" />
-                        {finding}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-
-                <div>
-                  <h3 className="text-sm font-semibold uppercase tracking-wide text-bayesiq-500">
-                    Business Impact
-                  </h3>
-                  <p className="mt-1 text-bayesiq-700">{study.impact}</p>
-                </div>
-
-                <div>
-                  <h3 className="text-sm font-semibold uppercase tracking-wide text-bayesiq-500">
-                    Remediation
-                  </h3>
-                  <p className="mt-1 text-bayesiq-700">{study.remediation}</p>
-                </div>
-
-                <div>
-                  <h3 className="text-sm font-semibold uppercase tracking-wide text-bayesiq-500">
-                    Deliverables
-                  </h3>
-                  <ul className="mt-1 space-y-1">
-                    {study.deliverables.map((d, j) => (
-                      <li
-                        key={j}
-                        className="flex items-start gap-2 text-bayesiq-700"
-                      >
-                        <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-bayesiq-400" />
-                        {d}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
-
-              <div className="mt-8 flex flex-wrap gap-3">
-                <Link
-                  href="/contact"
-                  className="rounded-lg bg-bayesiq-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
-                >
-                  {study.ctaText}
-                </Link>
-                <Link
-                  href="/consulting/sample-report"
-                  className="rounded-lg border border-bayesiq-300 px-4 py-2 text-sm font-medium text-bayesiq-700 transition-colors hover:bg-bayesiq-50"
-                >
-                  See a Sample Report
-                </Link>
-              </div>
-            </article>
+              </article>
+            </SectionReveal>
           ))}
         </div>
       </section>

--- a/src/app/consulting/sample-report/page.tsx
+++ b/src/app/consulting/sample-report/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import CTA from "@/components/CTA";
+import InlineEvidence from "@/components/InlineEvidence";
+import SectionReveal from "@/components/SectionReveal";
 
 export const metadata: Metadata = {
   title: "Sample Audit Report",
@@ -10,6 +12,7 @@ export const metadata: Metadata = {
     title: "Sample Audit Report — BayesIQ",
     description:
       "See what the BayesIQ Audit Kit actually produces: scored findings, dataset profiles, dbt projects, Streamlit dashboards, and machine-readable quality checks.",
+    url: "/consulting/sample-report",
   },
 };
 
@@ -216,293 +219,292 @@ export default function SampleReportPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(sampleReportJsonLd) }}
       />
-      {/* ---------------------------------------------------------------- */}
-      {/* Hero                                                              */}
-      {/* ---------------------------------------------------------------- */}
-      <section className="px-6 py-24 md:py-32">
-        <div className="mx-auto max-w-3xl">
-          <h1 className="text-4xl font-bold tracking-tight text-bayesiq-900 md:text-5xl">
-            What you get from a BayesIQ audit
-          </h1>
-          <p className="mt-6 text-lg leading-relaxed text-bayesiq-600">
-            Real artifacts from a real audit &mdash; not a PDF of
-            recommendations. The Audit Kit produces scored findings,
-            column-level profiles, data contracts, metric specs, a deployable
-            dbt project, and interactive dashboards.
-          </p>
-          <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center">
-            <Link
-              href="/contact"
-              className="inline-block rounded-lg bg-bayesiq-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
-            >
-              Start Your Audit
-            </Link>
-            <Link
-              href="/platform"
-              className="text-sm font-medium text-bayesiq-600 transition-colors hover:text-bayesiq-900"
-            >
-              See our services &rarr;
-            </Link>
-          </div>
-        </div>
-      </section>
 
-      {/* ---------------------------------------------------------------- */}
-      {/* Artifacts Overview                                                */}
-      {/* ---------------------------------------------------------------- */}
-      <section className="border-t border-bayesiq-200 bg-bayesiq-50 px-6 py-20">
-        <div className="mx-auto max-w-3xl">
-          <h2 className="text-2xl font-bold text-bayesiq-900">
-            Pipeline artifacts
-          </h2>
-          <p className="mt-3 text-base text-bayesiq-600">
-            Every audit produces these files. They land in your repo or shared
-            drive &mdash; no proprietary portal required.
-          </p>
-          <ul className="mt-8 space-y-6">
-            {artifacts.map((a) => (
-              <li key={a.file} className="flex gap-4">
-                <span
-                  className="mt-1 h-2 w-2 shrink-0 rounded-full bg-bayesiq-400"
-                  aria-hidden="true"
-                />
-                <div>
-                  <p className="text-sm font-semibold text-bayesiq-900">
-                    <code className="rounded bg-bayesiq-100 px-1.5 py-0.5 font-mono text-xs">
-                      {a.file}
-                    </code>
-                  </p>
-                  <p className="mt-1 text-sm leading-relaxed text-bayesiq-600">
-                    {a.description}
-                  </p>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </section>
-
-      {/* ---------------------------------------------------------------- */}
-      {/* Example Findings                                                  */}
-      {/* ---------------------------------------------------------------- */}
-      <section className="px-6 py-20">
-        <div className="mx-auto max-w-5xl">
-          <h2 className="text-2xl font-bold text-bayesiq-900">
-            Example findings from{" "}
-            <code className="rounded bg-bayesiq-100 px-1.5 py-0.5 font-mono text-xl">
-              audit_report.md
-            </code>
-          </h2>
-          <p className="mt-3 text-base text-bayesiq-600">
-            Anonymized excerpt from an Audit Kit run on a B2B SaaS product
-            (~50 M events/month). Finding IDs, event names, and property names
-            have been changed.
-          </p>
-          <div className="mt-8 space-y-6">
-            {findings.map((f) => (
-              <div
-                key={f.id}
-                className="rounded-lg border border-bayesiq-200 bg-white p-5"
+      {/* Hero */}
+      <SectionReveal>
+        <section className="px-6 py-24 md:py-32">
+          <div className="mx-auto max-w-3xl">
+            <h1 className="text-4xl font-bold tracking-tight text-bayesiq-900 md:text-5xl">
+              What you get from a BayesIQ audit
+            </h1>
+            <p className="mt-6 text-lg leading-relaxed text-bayesiq-600">
+              Real artifacts from a real audit &mdash; not a PDF of
+              recommendations. The Audit Kit produces scored findings,
+              column-level profiles, data contracts, metric specs, a deployable
+              dbt project, and interactive dashboards.
+            </p>
+            <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center">
+              <Link
+                href="/contact"
+                className="inline-block rounded-lg bg-bayesiq-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
               >
-                <div className="flex items-center gap-3">
-                  <span className="font-mono text-xs text-bayesiq-400">
-                    {f.id}
-                  </span>
+                Start Your Audit
+              </Link>
+              <Link
+                href="/consulting/case-studies"
+                className="text-sm font-medium text-bayesiq-600 transition-colors hover:text-bayesiq-900"
+              >
+                See case studies &rarr;
+              </Link>
+              <Link
+                href="/consulting/explore"
+                className="text-sm font-medium text-bayesiq-500 transition-colors hover:text-bayesiq-700"
+              >
+                Explore a live engagement &rarr;
+              </Link>
+            </div>
+          </div>
+        </section>
+      </SectionReveal>
+
+      {/* Artifacts Overview */}
+      <SectionReveal>
+        <section className="border-t border-bayesiq-200 bg-bayesiq-50 px-6 py-20">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-2xl font-bold text-bayesiq-900">
+              Pipeline artifacts
+            </h2>
+            <p className="mt-3 text-base text-bayesiq-600">
+              Every audit produces these files. They land in your repo or shared
+              drive &mdash; no proprietary portal required.
+            </p>
+            <ul className="mt-8 space-y-6">
+              {artifacts.map((a) => (
+                <li key={a.file} className="flex gap-4">
                   <span
-                    className={`inline-block rounded px-2 py-0.5 text-xs font-semibold ${f.severityColor}`}
-                  >
-                    {f.severity}
-                  </span>
-                </div>
-                <p className="mt-2 text-sm font-medium leading-relaxed text-bayesiq-900">
-                  {f.finding}
-                </p>
-                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                    className="mt-1 h-2 w-2 shrink-0 rounded-full bg-bayesiq-400"
+                    aria-hidden="true"
+                  />
                   <div>
-                    <p className="text-xs font-medium uppercase tracking-wider text-bayesiq-400">
-                      Root Cause
+                    <p className="text-sm font-semibold text-bayesiq-900">
+                      <InlineEvidence>{a.file}</InlineEvidence>
                     </p>
                     <p className="mt-1 text-sm leading-relaxed text-bayesiq-600">
-                      {f.rootCause}
+                      {a.description}
                     </p>
                   </div>
-                  <div>
-                    <p className="text-xs font-medium uppercase tracking-wider text-bayesiq-400">
-                      Recommended Fix
-                    </p>
-                    <p className="mt-1 text-sm leading-relaxed text-bayesiq-600">
-                      {f.fix}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            ))}
+                </li>
+              ))}
+            </ul>
           </div>
-        </div>
-      </section>
+        </section>
+      </SectionReveal>
 
-      {/* ---------------------------------------------------------------- */}
-      {/* Scoring Rubric                                                    */}
-      {/* ---------------------------------------------------------------- */}
-      <section className="border-t border-bayesiq-200 bg-bayesiq-50 px-6 py-20">
-        <div className="mx-auto max-w-3xl">
-          <h2 className="text-2xl font-bold text-bayesiq-900">
-            Scoring rubric (0&ndash;100)
-          </h2>
-          <p className="mt-3 text-base text-bayesiq-600">
-            Every audit produces an overall health score. The score reflects the
-            count, severity, and blast radius of confirmed issues.
-          </p>
-          <div className="mt-8 overflow-x-auto">
-            <table className="w-full border-collapse text-sm">
-              <thead>
-                <tr className="border-b border-bayesiq-200">
-                  <th
-                    scope="col"
-                    className="py-3 pr-6 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
-                  >
-                    Score
-                  </th>
-                  <th
-                    scope="col"
-                    className="py-3 pr-6 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
-                  >
-                    Rating
-                  </th>
-                  <th
-                    scope="col"
-                    className="py-3 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
-                  >
-                    What it means
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-bayesiq-100">
-                {scoringRubric.map((row) => (
-                  <tr key={row.label}>
-                    <td className="py-3 pr-6 align-top font-mono text-sm text-bayesiq-700">
-                      {row.range}
-                    </td>
-                    <td className="py-3 pr-6 align-top">
-                      <span
-                        className={`inline-block rounded border px-2 py-0.5 text-xs font-semibold ${row.color}`}
-                      >
-                        {row.label}
-                      </span>
-                    </td>
-                    <td className="py-3 align-top leading-relaxed text-bayesiq-600">
-                      {row.description}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </section>
-
-      {/* ---------------------------------------------------------------- */}
-      {/* Severity Definitions                                              */}
-      {/* ---------------------------------------------------------------- */}
-      <section className="px-6 py-20">
-        <div className="mx-auto max-w-3xl">
-          <h2 className="text-2xl font-bold text-bayesiq-900">
-            Severity definitions
-          </h2>
-          <p className="mt-3 text-base text-bayesiq-600">
-            Every finding is ranked by business impact and blast radius &mdash;
-            how many downstream metrics or reports does this affect?
-          </p>
-          <div className="mt-8 overflow-x-auto">
-            <table className="w-full border-collapse text-sm">
-              <thead>
-                <tr className="border-b border-bayesiq-200">
-                  <th
-                    scope="col"
-                    className="py-3 pr-6 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
-                  >
-                    Severity
-                  </th>
-                  <th
-                    scope="col"
-                    className="py-3 pr-6 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
-                  >
-                    Definition
-                  </th>
-                  <th
-                    scope="col"
-                    className="py-3 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
-                  >
-                    Typical action
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-bayesiq-100">
-                {severityDefinitions.map((row) => (
-                  <tr key={row.level}>
-                    <td className="py-3 pr-6 align-top">
-                      <span
-                        className={`inline-block rounded border px-2 py-0.5 text-xs font-semibold ${row.color}`}
-                      >
-                        {row.level}
-                      </span>
-                    </td>
-                    <td className="py-3 pr-6 align-top leading-relaxed text-bayesiq-700">
-                      {row.definition}
-                    </td>
-                    <td className="py-3 align-top text-bayesiq-600">
-                      {row.action}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </section>
-
-      {/* ---------------------------------------------------------------- */}
-      {/* Engagement Timeline                                               */}
-      {/* ---------------------------------------------------------------- */}
-      <section className="border-t border-bayesiq-200 bg-bayesiq-50 px-6 py-20">
-        <div className="mx-auto max-w-3xl">
-          <h2 className="text-2xl font-bold text-bayesiq-900">
-            Engagement timeline &mdash; 6 weeks
-          </h2>
-          <p className="mt-3 text-base text-bayesiq-600">
-            A full engagement runs 6 weeks from kickoff to validated dashboards.
-            Diagnostic sprints deliver findings in 1 week.
-          </p>
-          <div className="mt-10 space-y-8">
-            {timelineSteps.map((step, index) => (
-              <div key={step.phase} className="flex gap-6">
-                <div className="flex shrink-0 flex-col items-center">
-                  <span className="text-sm font-bold text-bayesiq-300">
-                    {String(index + 1).padStart(2, "0")}
-                  </span>
-                </div>
-                <div>
-                  <div className="flex items-baseline gap-3">
-                    <h3 className="text-base font-semibold text-bayesiq-900">
-                      {step.phase}
-                    </h3>
-                    <span className="text-xs text-bayesiq-400">
-                      {step.timeline}
+      {/* Example Findings */}
+      <SectionReveal>
+        <section className="px-6 py-20">
+          <div className="mx-auto max-w-5xl">
+            <h2 className="text-2xl font-bold text-bayesiq-900">
+              Example findings from{" "}
+              <InlineEvidence className="text-xl">audit_report.md</InlineEvidence>
+            </h2>
+            <p className="mt-3 text-base text-bayesiq-600">
+              Anonymized excerpt from an Audit Kit run on a B2B SaaS product
+              (~50 M events/month). Finding IDs, event names, and property names
+              have been changed.
+            </p>
+            <div className="mt-8 space-y-6">
+              {findings.map((f) => (
+                <div
+                  key={f.id}
+                  className="rounded-lg border border-bayesiq-200 bg-white p-5"
+                >
+                  <div className="flex items-center gap-3">
+                    <InlineEvidence>{f.id}</InlineEvidence>
+                    <span
+                      className={`inline-block rounded px-2 py-0.5 text-xs font-semibold ${f.severityColor}`}
+                    >
+                      {f.severity}
                     </span>
                   </div>
-                  <p className="mt-1 text-sm leading-relaxed text-bayesiq-600">
-                    {step.description}
+                  <p className="mt-2 text-sm font-medium leading-relaxed text-bayesiq-900">
+                    {f.finding}
                   </p>
+                  <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wider text-bayesiq-400">
+                        Root Cause
+                      </p>
+                      <p className="mt-1 text-sm leading-relaxed text-bayesiq-600">
+                        {f.rootCause}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium uppercase tracking-wider text-bayesiq-400">
+                        Recommended Fix
+                      </p>
+                      <p className="mt-1 text-sm leading-relaxed text-bayesiq-600">
+                        {f.fix}
+                      </p>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </SectionReveal>
 
-      {/* ---------------------------------------------------------------- */}
-      {/* CTA                                                               */}
-      {/* ---------------------------------------------------------------- */}
+      {/* Scoring Rubric */}
+      <SectionReveal>
+        <section className="border-t border-bayesiq-200 bg-bayesiq-50 px-6 py-20">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-2xl font-bold text-bayesiq-900">
+              Scoring rubric (0&ndash;100)
+            </h2>
+            <p className="mt-3 text-base text-bayesiq-600">
+              Every audit produces an overall health score. The score reflects the
+              count, severity, and blast radius of confirmed issues.
+            </p>
+            <div className="mt-8 overflow-x-auto">
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="border-b border-bayesiq-200">
+                    <th
+                      scope="col"
+                      className="py-3 pr-6 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
+                    >
+                      Score
+                    </th>
+                    <th
+                      scope="col"
+                      className="py-3 pr-6 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
+                    >
+                      Rating
+                    </th>
+                    <th
+                      scope="col"
+                      className="py-3 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
+                    >
+                      What it means
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-bayesiq-100">
+                  {scoringRubric.map((row) => (
+                    <tr key={row.label}>
+                      <td className="py-3 pr-6 align-top font-mono text-sm text-bayesiq-700">
+                        {row.range}
+                      </td>
+                      <td className="py-3 pr-6 align-top">
+                        <span
+                          className={`inline-block rounded border px-2 py-0.5 text-xs font-semibold ${row.color}`}
+                        >
+                          {row.label}
+                        </span>
+                      </td>
+                      <td className="py-3 align-top leading-relaxed text-bayesiq-600">
+                        {row.description}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      </SectionReveal>
+
+      {/* Severity Definitions */}
+      <SectionReveal>
+        <section className="px-6 py-20">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-2xl font-bold text-bayesiq-900">
+              Severity definitions
+            </h2>
+            <p className="mt-3 text-base text-bayesiq-600">
+              Every finding is ranked by business impact and blast radius &mdash;
+              how many downstream metrics or reports does this affect?
+            </p>
+            <div className="mt-8 overflow-x-auto">
+              <table className="w-full border-collapse text-sm">
+                <thead>
+                  <tr className="border-b border-bayesiq-200">
+                    <th
+                      scope="col"
+                      className="py-3 pr-6 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
+                    >
+                      Severity
+                    </th>
+                    <th
+                      scope="col"
+                      className="py-3 pr-6 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
+                    >
+                      Definition
+                    </th>
+                    <th
+                      scope="col"
+                      className="py-3 text-left text-xs font-medium uppercase tracking-wider text-bayesiq-400"
+                    >
+                      Typical action
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-bayesiq-100">
+                  {severityDefinitions.map((row) => (
+                    <tr key={row.level}>
+                      <td className="py-3 pr-6 align-top">
+                        <span
+                          className={`inline-block rounded border px-2 py-0.5 text-xs font-semibold ${row.color}`}
+                        >
+                          {row.level}
+                        </span>
+                      </td>
+                      <td className="py-3 pr-6 align-top leading-relaxed text-bayesiq-700">
+                        {row.definition}
+                      </td>
+                      <td className="py-3 align-top text-bayesiq-600">
+                        {row.action}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+      </SectionReveal>
+
+      {/* Engagement Timeline */}
+      <SectionReveal>
+        <section className="border-t border-bayesiq-200 bg-bayesiq-50 px-6 py-20">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="text-2xl font-bold text-bayesiq-900">
+              Engagement timeline &mdash; 6 weeks
+            </h2>
+            <p className="mt-3 text-base text-bayesiq-600">
+              A full engagement runs 6 weeks from kickoff to validated dashboards.
+              Diagnostic sprints deliver findings in 1 week.
+            </p>
+            <div className="mt-10 space-y-8">
+              {timelineSteps.map((step, index) => (
+                <div key={step.phase} className="flex gap-6">
+                  <div className="flex shrink-0 flex-col items-center">
+                    <span className="text-sm font-bold text-bayesiq-300">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                  </div>
+                  <div>
+                    <div className="flex items-baseline gap-3">
+                      <h3 className="text-base font-semibold text-bayesiq-900">
+                        {step.phase}
+                      </h3>
+                      <span className="text-xs text-bayesiq-400">
+                        {step.timeline}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-sm leading-relaxed text-bayesiq-600">
+                      {step.description}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </SectionReveal>
+
+      {/* CTA */}
       <CTA
         headline="See it on your data"
         description="Drop a CSV in the playground for instant profiling, or book a diagnostic sprint."

--- a/src/components/AnimatedCounter.tsx
+++ b/src/components/AnimatedCounter.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useInView, animate } from "framer-motion";
+
+interface AnimatedCounterProps {
+  from: number;
+  to: number;
+  duration?: number;
+  className?: string;
+  /** Optional label rendered after the number */
+  suffix?: string;
+}
+
+export default function AnimatedCounter({
+  from,
+  to,
+  duration = 1.2,
+  className = "",
+  suffix,
+}: AnimatedCounterProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const isInView = useInView(ref, { once: true, margin: "-40px" });
+  const [displayValue, setDisplayValue] = useState(from);
+
+  useEffect(() => {
+    if (!isInView) return;
+
+    const controls = animate(from, to, {
+      duration,
+      ease: "easeOut",
+      onUpdate(value) {
+        setDisplayValue(Math.round(value));
+      },
+    });
+
+    return () => controls.stop();
+  }, [isInView, from, to, duration]);
+
+  return (
+    <span ref={ref} className={className}>
+      {displayValue}
+      {suffix}
+    </span>
+  );
+}

--- a/src/components/BeforeAfterSplit.tsx
+++ b/src/components/BeforeAfterSplit.tsx
@@ -1,0 +1,100 @@
+interface BeforeAfterSplitProps {
+  before: {
+    label: string;
+    score: number;
+    severity: string;
+    details: string;
+  };
+  after: {
+    label: string;
+    score: number;
+    tier: string;
+    details: string;
+  };
+}
+
+function severityBorderColor(severity: string): string {
+  switch (severity) {
+    case "Critical":
+      return "border-red-300";
+    case "Needs Attention":
+      return "border-orange-300";
+    case "High":
+      return "border-orange-300";
+    default:
+      return "border-yellow-300";
+  }
+}
+
+function severityBadgeClasses(severity: string): string {
+  switch (severity) {
+    case "Critical":
+      return "bg-red-50 text-red-700 border-red-200";
+    case "Needs Attention":
+      return "bg-orange-50 text-orange-700 border-orange-200";
+    case "High":
+      return "bg-orange-50 text-orange-700 border-orange-200";
+    default:
+      return "bg-yellow-50 text-yellow-700 border-yellow-200";
+  }
+}
+
+export default function BeforeAfterSplit({
+  before,
+  after,
+}: BeforeAfterSplitProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {/* Before */}
+      <div
+        className={`rounded-xl border-2 ${severityBorderColor(before.severity)} bg-red-50/30 p-5`}
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-semibold uppercase tracking-wider text-red-600">
+            {before.label}
+          </span>
+          <span
+            className={`inline-block rounded border px-2 py-0.5 text-xs font-semibold ${severityBadgeClasses(before.severity)}`}
+          >
+            {before.severity}
+          </span>
+        </div>
+        <p className="mt-3 font-mono text-3xl font-bold text-red-700">
+          {before.score}
+          <span className="text-sm font-normal text-red-500">/100</span>
+        </p>
+        <p className="mt-2 text-sm leading-relaxed text-red-800/70">
+          {before.details}
+        </p>
+      </div>
+
+      {/* Divider for mobile */}
+      <div className="flex items-center justify-center md:hidden">
+        <div className="h-px w-12 bg-bayesiq-300" />
+        <span className="mx-3 text-xs font-semibold text-bayesiq-400">
+          AFTER BAYESIQ
+        </span>
+        <div className="h-px w-12 bg-bayesiq-300" />
+      </div>
+
+      {/* After */}
+      <div className="rounded-xl border-2 border-green-300 bg-green-50/30 p-5">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-semibold uppercase tracking-wider text-green-600">
+            {after.label}
+          </span>
+          <span className="inline-block rounded border border-green-200 bg-green-50 px-2 py-0.5 text-xs font-semibold text-green-700">
+            {after.tier}
+          </span>
+        </div>
+        <p className="mt-3 font-mono text-3xl font-bold text-green-700">
+          {after.score}
+          <span className="text-sm font-normal text-green-500">/100</span>
+        </p>
+        <p className="mt-2 text-sm leading-relaxed text-green-800/70">
+          {after.details}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/InlineEvidence.tsx
+++ b/src/components/InlineEvidence.tsx
@@ -1,0 +1,21 @@
+interface InlineEvidenceProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Wraps finding IDs, file names, scores, and other evidence artifacts
+ * in JetBrains Mono (font-mono) with a subtle background.
+ */
+export default function InlineEvidence({
+  children,
+  className = "",
+}: InlineEvidenceProps) {
+  return (
+    <code
+      className={`rounded bg-bayesiq-100 px-1.5 py-0.5 font-mono text-xs font-medium ${className}`}
+    >
+      {children}
+    </code>
+  );
+}

--- a/src/components/__tests__/AnimatedCounter.test.tsx
+++ b/src/components/__tests__/AnimatedCounter.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import AnimatedCounter from "../AnimatedCounter";
+
+// Mock framer-motion
+vi.mock("framer-motion", () => ({
+  useInView: vi.fn(() => false),
+  animate: vi.fn(() => ({ stop: vi.fn() })),
+}));
+
+describe("AnimatedCounter", () => {
+  it("renders the start value initially when not in view", () => {
+    render(<AnimatedCounter from={38} to={87} />);
+    expect(screen.getByText("38")).toBeTruthy();
+  });
+
+  it("renders with suffix when provided", () => {
+    render(<AnimatedCounter from={38} to={87} suffix="/100" />);
+    expect(screen.getByText("38/100")).toBeTruthy();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <AnimatedCounter from={0} to={100} className="font-mono text-xl" />
+    );
+    const span = container.querySelector("span");
+    expect(span?.className).toContain("font-mono");
+    expect(span?.className).toContain("text-xl");
+  });
+
+  it("animates to end value when in view", async () => {
+    const { useInView, animate: mockAnimate } = await import("framer-motion");
+    vi.mocked(useInView).mockReturnValue(true);
+
+    // Capture the onUpdate callback
+    vi.mocked(mockAnimate).mockImplementation((_from, _to, options) => {
+      if (options?.onUpdate) {
+        options.onUpdate(87);
+      }
+      return { stop: vi.fn() } as ReturnType<typeof mockAnimate>;
+    });
+
+    render(<AnimatedCounter from={38} to={87} />);
+    expect(screen.getByText("87")).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/BeforeAfterSplit.test.tsx
+++ b/src/components/__tests__/BeforeAfterSplit.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import BeforeAfterSplit from "../BeforeAfterSplit";
+
+const defaultProps = {
+  before: {
+    label: "Before Audit",
+    score: 38,
+    severity: "Critical",
+    details: "Metrics were broken.",
+  },
+  after: {
+    label: "After Remediation",
+    score: 87,
+    tier: "Audit + Plan",
+    details: "Metrics are now reliable.",
+  },
+};
+
+describe("BeforeAfterSplit", () => {
+  it("renders both before and after content", () => {
+    render(<BeforeAfterSplit {...defaultProps} />);
+    expect(screen.getByText("Before Audit")).toBeTruthy();
+    expect(screen.getByText("After Remediation")).toBeTruthy();
+    expect(screen.getByText("Metrics were broken.")).toBeTruthy();
+    expect(screen.getByText("Metrics are now reliable.")).toBeTruthy();
+  });
+
+  it("renders severity badge with correct text", () => {
+    render(<BeforeAfterSplit {...defaultProps} />);
+    expect(screen.getByText("Critical")).toBeTruthy();
+  });
+
+  it("renders tier badge in after column", () => {
+    render(<BeforeAfterSplit {...defaultProps} />);
+    expect(screen.getByText("Audit + Plan")).toBeTruthy();
+  });
+
+  it("renders scores", () => {
+    const { container } = render(<BeforeAfterSplit {...defaultProps} />);
+    // Both score values present (as text content within the font-mono spans)
+    const monoElements = container.querySelectorAll(".font-mono");
+    const textContent = Array.from(monoElements).map((el) => el.textContent);
+    expect(textContent.some((t) => t?.includes("38"))).toBe(true);
+    expect(textContent.some((t) => t?.includes("87"))).toBe(true);
+  });
+
+  it("applies correct severity color classes for Critical", () => {
+    const { container } = render(<BeforeAfterSplit {...defaultProps} />);
+    // The before card should have red-themed border
+    const beforeCard = container.querySelector(".border-red-300");
+    expect(beforeCard).toBeTruthy();
+  });
+
+  it("applies correct severity color classes for Needs Attention", () => {
+    const props = {
+      ...defaultProps,
+      before: { ...defaultProps.before, severity: "Needs Attention" },
+    };
+    const { container } = render(<BeforeAfterSplit {...props} />);
+    const beforeCard = container.querySelector(".border-orange-300");
+    expect(beforeCard).toBeTruthy();
+  });
+
+  it("has green-themed after column", () => {
+    const { container } = render(<BeforeAfterSplit {...defaultProps} />);
+    const afterCard = container.querySelector(".border-green-300");
+    expect(afterCard).toBeTruthy();
+  });
+
+  it("has mobile divider with AFTER BAYESIQ text", () => {
+    render(<BeforeAfterSplit {...defaultProps} />);
+    expect(screen.getByText("AFTER BAYESIQ")).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/InlineEvidence.test.tsx
+++ b/src/components/__tests__/InlineEvidence.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import InlineEvidence from "../InlineEvidence";
+
+describe("InlineEvidence", () => {
+  it("renders children correctly", () => {
+    render(<InlineEvidence>F-01</InlineEvidence>);
+    expect(screen.getByText("F-01")).toBeTruthy();
+  });
+
+  it("applies font-mono class", () => {
+    const { container } = render(
+      <InlineEvidence>audit_report.md</InlineEvidence>
+    );
+    const code = container.querySelector("code");
+    expect(code?.className).toContain("font-mono");
+  });
+
+  it("renders as a code element", () => {
+    const { container } = render(
+      <InlineEvidence>ASSUMPTIONS.md</InlineEvidence>
+    );
+    const code = container.querySelector("code");
+    expect(code).toBeTruthy();
+    expect(code?.textContent).toBe("ASSUMPTIONS.md");
+  });
+
+  it("applies custom className in addition to defaults", () => {
+    const { container } = render(
+      <InlineEvidence className="text-xl">test</InlineEvidence>
+    );
+    const code = container.querySelector("code");
+    expect(code?.className).toContain("font-mono");
+    expect(code?.className).toContain("text-xl");
+  });
+});

--- a/src/components/__tests__/SectionReveal.test.tsx
+++ b/src/components/__tests__/SectionReveal.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import SectionReveal from "../SectionReveal";
+
+// Mock framer-motion
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({
+      children,
+      className,
+      ...props
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      [key: string]: unknown;
+    }) => (
+      <div className={className} data-testid="motion-div" {...props}>
+        {children}
+      </div>
+    ),
+  },
+  useInView: vi.fn(() => true),
+}));
+
+describe("SectionReveal", () => {
+  it("renders children", () => {
+    render(
+      <SectionReveal>
+        <p>Hello World</p>
+      </SectionReveal>
+    );
+    expect(screen.getByText("Hello World")).toBeTruthy();
+  });
+
+  it("applies custom className", () => {
+    render(
+      <SectionReveal className="mt-8">
+        <p>Content</p>
+      </SectionReveal>
+    );
+    const wrapper = screen.getByTestId("motion-div");
+    expect(wrapper.className).toContain("mt-8");
+  });
+});


### PR DESCRIPTION
## Summary
- AnimatedCounter for score improvements (38→87, 52→84, 44→82)
- BeforeAfterSplit component for before/after findings
- InlineEvidence component (JetBrains Mono for artifact names)
- SectionReveal scroll animations
- Shuk placeholder (hidden, ready for post-contract)
- 32 new tests

## Test plan
- [x] npm run build passes
- [x] 109 tests pass

issue: null