### PR TITLE
Fix GovernanceChain mobile text cutoff

### DIFF
--- a/src/components/GovernanceChain.tsx
+++ b/src/components/GovernanceChain.tsx
@@ -46,8 +46,9 @@ export default function GovernanceChain({
   const verticalSpacing = 80;
   const svgHeightVertical =
     (nodes.length - 1) * verticalSpacing + nodeRadius * 2 + 60;
-  const centerX = 60;
+  const centerX = 30;
   const startY = nodeRadius + 20;
+  const svgWidthVertical = 160;
 
   return (
     <div data-testid="governance-chain">
@@ -116,8 +117,8 @@ export default function GovernanceChain({
 
       {/* Mobile: vertical */}
       <svg
-        viewBox={`0 0 120 ${svgHeightVertical}`}
-        className="mx-auto block w-28 md:hidden"
+        viewBox={`0 0 ${svgWidthVertical} ${svgHeightVertical}`}
+        className="mx-auto block w-40 md:hidden"
         role="img"
         aria-label={`Governance chain: ${nodes.map((n) => n.label).join(" to ")}`}
       >


### PR DESCRIPTION
## Summary
Fix the vertical governance chain on mobile where "Raw Data", "Reviewed", and "Approved" labels were getting clipped.

- Shift nodes left (centerX 60→30)
- Widen SVG viewBox (120→160) and container (w-28→w-40)
- Labels now have 100px of room instead of 30px

issue: null

## Test plan
- [x] `npm run build` passes
- [ ] Visual check: governance chain labels visible on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)