### PR TITLE
Add pixel-diff comparison + design debt tracking (Phase 2)

### DIFF
--- a/docs/ai/session-feedback.md
+++ b/docs/ai/session-feedback.md
@@ -73,6 +73,13 @@ instead of at the repo root. Always `cd` to the main repo root before
 - Add early guard if test-results/visual-qa/ is missing
 - Ensure TypeScript runner (tsx/ts-node) available for visual-review.ts
 
+### PR-C (Phase 2) — plan-critic approved-with-notes (7 findings, 3 attempts)
+- TS script runner strategy (node vs tsx) must be resolved at wiring time
+- Findings JSON schema validation needs graceful degradation
+- `diffs/` directory creation should use mkdir -p for idempotency
+- @types/pngjs needed for TypeScript compilation
+- npm script must exist before shell wiring is exercised (atomic commit)
+
 ### Worktree session scope issue
 bash-guard detects `source ~/BayesIQCode/bayesiq-workspace/gh-api.sh` as a
 cross-repo write when CWD is inside a worktree. Workaround: `cd` to the

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.0.0",
+        "@types/pngjs": "^6.0.5",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.1",
@@ -33,7 +34,10 @@
         "ajv-formats": "^3.0.1",
         "jsdom": "^29.0.0",
         "json-schema-to-typescript": "^15.0.4",
+        "pixelmatch": "^7.1.0",
+        "pngjs": "^7.0.0",
         "tailwindcss": "^4.0.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.7.0",
         "vitest": "^4.1.0"
       }
@@ -367,6 +371,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -1911,6 +2357,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2572,6 +3028,48 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -2803,6 +3301,19 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
+      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -4727,6 +5238,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pixelmatch": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
+      "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
@@ -4757,6 +5281,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postal-mime": {
@@ -5080,6 +5614,16 @@
         "@react-email/render": {
           "optional": true
         }
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rolldown": {
@@ -5501,6 +6045,41 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "visual-qa": "npx playwright test e2e/visual-qa.spec.ts --project=chromium --reporter=list",
     "visual-qa:baseline": "bash scripts/visual-qa-baseline.sh",
     "a11y-check": "npx playwright test e2e/a11y-check.spec.ts --project=chromium --reporter=list",
-    "visual-review": "echo 'Run: npm run visual-qa && then review screenshots with the visual-review-prompt.md template'"
+    "visual-review": "echo 'Run: npm run visual-qa && then review screenshots with the visual-review-prompt.md template'",
+    "pixel-diff": "npx tsx scripts/pixel-diff.ts",
+    "design-debt": "npx tsx scripts/design-debt.ts"
   },
   "dependencies": {
     "@vercel/analytics": "^1.6.1",
@@ -36,6 +38,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.0.0",
+    "@types/pngjs": "^6.0.5",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.1",
@@ -43,7 +46,10 @@
     "ajv-formats": "^3.0.1",
     "jsdom": "^29.0.0",
     "json-schema-to-typescript": "^15.0.4",
+    "pixelmatch": "^7.1.0",
+    "pngjs": "^7.0.0",
     "tailwindcss": "^4.0.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"
   }

--- a/scripts/design-debt.ts
+++ b/scripts/design-debt.ts
@@ -1,0 +1,101 @@
+import { readFileSync, existsSync, readdirSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+
+const FINDINGS_DIR = "test-results/visual-qa/findings";
+const DEBT_FILE = "test-results/visual-qa/debt-scores.json";
+const SEVERITY_WEIGHTS: Record<string, number> = {
+  regression: 5,
+  violation: 3,
+  nit: 1,
+  suggestion: 0.5,
+};
+const THRESHOLD = 10;
+
+interface Finding {
+  layer: string;
+  severity: string;
+  description: string;
+}
+
+interface PageFindings {
+  page: string;
+  findings: Finding[];
+}
+
+interface FindingsReport {
+  timestamp: string;
+  pages: PageFindings[];
+}
+
+function run() {
+  if (!existsSync(FINDINGS_DIR)) {
+    mkdirSync(FINDINGS_DIR, { recursive: true });
+    console.log("No findings directory. Creating empty one.");
+    console.log("Run visual reviews and save findings to test-results/visual-qa/findings/");
+    process.exit(0);
+  }
+
+  const files = readdirSync(FINDINGS_DIR).filter(f => f.endsWith(".json"));
+  if (files.length === 0) {
+    console.log("No findings files found. Run a visual review first.");
+    process.exit(0);
+  }
+
+  const debtScores: Record<string, { score: number; findings: number; breakdown: Record<string, number> }> = {};
+
+  for (const file of files) {
+    try {
+      const report: FindingsReport = JSON.parse(readFileSync(join(FINDINGS_DIR, file), "utf-8"));
+      for (const page of report.pages) {
+        if (!debtScores[page.page]) {
+          debtScores[page.page] = { score: 0, findings: 0, breakdown: {} };
+        }
+        for (const finding of page.findings) {
+          const weight = SEVERITY_WEIGHTS[finding.severity] ?? 1;
+          debtScores[page.page].score += weight;
+          debtScores[page.page].findings++;
+          debtScores[page.page].breakdown[finding.severity] =
+            (debtScores[page.page].breakdown[finding.severity] ?? 0) + 1;
+        }
+      }
+    } catch {
+      console.warn(`Skipping invalid findings file: ${file}`);
+    }
+  }
+
+  console.log("\n=== Design Debt Scores ===\n");
+  console.log("Page".padEnd(40) + "Score".padEnd(8) + "Findings".padEnd(10) + "Status");
+  console.log("-".repeat(70));
+
+  const sorted = Object.entries(debtScores).sort((a, b) => b[1].score - a[1].score);
+  let alertCount = 0;
+
+  for (const [page, data] of sorted) {
+    const status = data.score >= THRESHOLD ? "OVER THRESHOLD" : "OK";
+    if (data.score >= THRESHOLD) alertCount++;
+    console.log(
+      page.padEnd(40) +
+      data.score.toFixed(1).padEnd(8) +
+      String(data.findings).padEnd(10) +
+      status
+    );
+  }
+
+  if (sorted.length === 0) {
+    console.log("  No pages with findings.");
+  }
+
+  // Save scores
+  mkdirSync("test-results/visual-qa", { recursive: true });
+  writeFileSync(DEBT_FILE, JSON.stringify({
+    timestamp: new Date().toISOString(),
+    scores: debtScores
+  }, null, 2));
+  console.log(`\nScores saved to ${DEBT_FILE}`);
+
+  if (alertCount > 0) {
+    console.log(`\n${alertCount} page(s) exceed debt threshold (${THRESHOLD}).`);
+  }
+}
+
+run();

--- a/scripts/pixel-diff.ts
+++ b/scripts/pixel-diff.ts
@@ -1,0 +1,111 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "fs";
+import { join } from "path";
+import { PNG } from "pngjs";
+import pixelmatch from "pixelmatch";
+
+const BASELINE_DIR = "test-results/visual-qa/baseline";
+const CURRENT_DIR = "test-results/visual-qa";
+const DIFF_DIR = "test-results/visual-qa/diffs";
+
+function run() {
+  if (!existsSync(BASELINE_DIR)) {
+    console.log("No baseline found. Run: npm run visual-qa:baseline approve");
+    process.exit(0);
+  }
+
+  const baselineFiles = readdirSync(BASELINE_DIR).filter(f => f.endsWith(".png"));
+  if (baselineFiles.length === 0) {
+    console.log("Baseline is empty. Run: npm run visual-qa && npm run visual-qa:baseline approve");
+    process.exit(0);
+  }
+
+  // Check if there are any current screenshots to compare against
+  const currentPngs = existsSync(CURRENT_DIR)
+    ? readdirSync(CURRENT_DIR).filter(
+        f => f.endsWith(".png") && !f.startsWith("diff-")
+      )
+    : [];
+
+  if (currentPngs.length === 0) {
+    console.log("No latest screenshots found. Run: npm run visual-qa");
+    process.exit(1);
+  }
+
+  mkdirSync(DIFF_DIR, { recursive: true });
+
+  let changed = 0;
+  let unchanged = 0;
+  let missing = 0;
+  const results: Array<{ file: string; status: string; diffPercent?: number }> = [];
+
+  for (const file of baselineFiles) {
+    const baselinePath = join(BASELINE_DIR, file);
+    const currentPath = join(CURRENT_DIR, file);
+
+    if (!existsSync(currentPath)) {
+      results.push({ file, status: "missing" });
+      missing++;
+      continue;
+    }
+
+    const baselineImg = PNG.sync.read(readFileSync(baselinePath));
+    const currentImg = PNG.sync.read(readFileSync(currentPath));
+
+    if (baselineImg.width !== currentImg.width || baselineImg.height !== currentImg.height) {
+      results.push({ file, status: "size-changed", diffPercent: 100 });
+      changed++;
+      continue;
+    }
+
+    const { width, height } = baselineImg;
+    const diff = new PNG({ width, height });
+    const numDiffPixels = pixelmatch(
+      baselineImg.data,
+      currentImg.data,
+      diff.data,
+      width,
+      height,
+      { threshold: 0.1 }
+    );
+
+    const diffPercent = (numDiffPixels / (width * height)) * 100;
+
+    if (numDiffPixels === 0) {
+      results.push({ file, status: "unchanged", diffPercent: 0 });
+      unchanged++;
+    } else {
+      results.push({ file, status: "changed", diffPercent: Math.round(diffPercent * 100) / 100 });
+      changed++;
+      writeFileSync(join(DIFF_DIR, `diff-${file}`), PNG.sync.write(diff));
+    }
+  }
+
+  // Check for new screenshots not in baseline
+  for (const file of currentPngs) {
+    if (!baselineFiles.includes(file)) {
+      results.push({ file, status: "new" });
+    }
+  }
+
+  console.log("\n=== Pixel Diff Summary ===");
+  console.log(`Unchanged: ${unchanged}`);
+  console.log(`Changed:   ${changed}`);
+  console.log(`Missing:   ${missing}`);
+  console.log("");
+
+  for (const r of results.filter(r => r.status !== "unchanged")) {
+    const detail = r.diffPercent !== undefined ? ` (${r.diffPercent}% diff)` : "";
+    console.log(`  [${r.status.toUpperCase()}] ${r.file}${detail}`);
+  }
+
+  if (changed === 0 && missing === 0) {
+    console.log("\nNo visual changes detected.");
+    process.exit(0);
+  } else {
+    console.log(`\n${changed} page(s) changed, ${missing} missing.`);
+    console.log(`Diff images saved to ${DIFF_DIR}/`);
+    process.exit(1);
+  }
+}
+
+run();

--- a/scripts/visual-qa-baseline.sh
+++ b/scripts/visual-qa-baseline.sh
@@ -14,12 +14,13 @@ META_FILE="$BASELINE_DIR/.baseline-meta.json"
 
 case "${1:-status}" in
   approve)
+    MESSAGE="${2:-"Baseline approved"}"
     mkdir -p "$BASELINE_DIR"
     # Copy all PNGs from latest to baseline (excluding baseline/ itself)
     find "$LATEST_DIR" -maxdepth 1 -name "*.png" -exec cp {} "$BASELINE_DIR/" \;
     # Write metadata
-    page_count=$(find "$BASELINE_DIR" -name "*.png" | wc -l | tr -d ' ')
-    echo "{\"commit\": \"$(git rev-parse HEAD)\", \"date\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"pages\": $page_count}" > "$META_FILE"
+    COUNT=$(find "$BASELINE_DIR" -name "*.png" | wc -l | tr -d ' ')
+    echo "{\"commit\": \"$(git rev-parse HEAD)\", \"date\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"pages\": $COUNT, \"message\": \"$MESSAGE\"}" > "$META_FILE"
     echo "Baseline approved: $(cat "$META_FILE")"
     ;;
   compare)
@@ -27,12 +28,8 @@ case "${1:-status}" in
       echo "No baseline found. Run 'approve' first."
       exit 1
     fi
-    baseline_count=$(find "$BASELINE_DIR" -name "*.png" | wc -l | tr -d ' ')
-    latest_count=$(find "$LATEST_DIR" -maxdepth 1 -name "*.png" | wc -l | tr -d ' ')
-    echo "Baseline files:"
-    echo "  $baseline_count screenshots"
-    echo "Latest files:"
-    echo "  $latest_count screenshots"
+    echo "Running pixel diff..."
+    npx tsx scripts/pixel-diff.ts
     ;;
   status)
     if [ -f "$META_FILE" ]; then


### PR DESCRIPTION
## Summary
- Add pixel-diff screenshot comparison (pixelmatch) with diff image generation
- Add per-page design debt scoring from findings JSON
- Enhance baseline management with --message flag and pixel-diff integration
- Persist plan-critic feedback to session-feedback.md

Phase 2 of Visual QA Agent. Completes P0-P2 rollout.

issue: null

## Test plan
- [x] npm run build passes
- [x] pixel-diff handles no-baseline gracefully
- [x] design-debt handles empty findings gracefully

Generated with Claude Code