### PR TITLE
Add narrative spine to golden flows exec UX

### DIFF
--- a/src/app/consulting/explore/[vertical]/page.tsx
+++ b/src/app/consulting/explore/[vertical]/page.tsx
@@ -29,6 +29,9 @@ import DecisionLog from "@/components/golden-flows/DecisionLog";
 import GovernanceDetailProvider from "@/components/golden-flows/GovernanceDetailProvider";
 import ReportPreview from "@/components/golden-flows/ReportPreview";
 import DashboardGrid from "@/components/golden-flows/DashboardGrid";
+import WhyThisMatters from "@/components/golden-flows/WhyThisMatters";
+import RemediationArc from "@/components/golden-flows/RemediationArc";
+import BayesIQDifference from "@/components/golden-flows/BayesIQDifference";
 
 interface Props {
   params: Promise<{ vertical: string }>;
@@ -236,6 +239,20 @@ export default async function ExploreVerticalPage({ params }: Props) {
             </a>
           </div>
         </div>
+
+        {boardReport && boardReport.top_risks.length > 0 && (
+          <WhyThisMatters risks={boardReport.top_risks} />
+        )}
+
+        {trajectory && boardReport && (
+          <RemediationArc
+            snapshots={trajectory.snapshots}
+            totalFindings={boardReport.total_findings}
+            topAction={boardReport.recommended_actions[0] ?? null}
+          />
+        )}
+
+        <BayesIQDifference />
 
         <GoldenFlowsCTA
           ctaLabel={narrative?.cta_label}

--- a/src/components/golden-flows/BayesIQDifference.tsx
+++ b/src/components/golden-flows/BayesIQDifference.tsx
@@ -1,22 +1,49 @@
-const DIFFERENTIATORS = [
+import type { ReactNode } from "react";
+
+interface Differentiator {
+  icon: ReactNode;
+  text: string;
+}
+
+const DIFFERENTIATORS: Differentiator[] = [
   {
-    icon: "🔗",
+    icon: (
+      <svg className="h-5 w-5 text-biq-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m9.86-2.702a4.5 4.5 0 00-1.242-7.244l-4.5-4.5a4.5 4.5 0 00-6.364 6.364L4.343 8.69" />
+      </svg>
+    ),
     text: "Findings connected to business meaning",
   },
   {
-    icon: "📊",
+    icon: (
+      <svg className="h-5 w-5 text-biq-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+      </svg>
+    ),
     text: "Operational and executive surfaces produced",
   },
   {
-    icon: "✓",
+    icon: (
+      <svg className="h-5 w-5 text-biq-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+    ),
     text: "Remediation governed and tracked",
   },
   {
-    icon: "📋",
+    icon: (
+      <svg className="h-5 w-5 text-biq-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+      </svg>
+    ),
     text: "Evidence and decisions preserved",
   },
   {
-    icon: "📈",
+    icon: (
+      <svg className="h-5 w-5 text-biq-primary" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
+      </svg>
+    ),
     text: "Metric confidence legible over time",
   },
 ];
@@ -33,7 +60,7 @@ export default function BayesIQDifference() {
             key={d.text}
             className="flex items-start gap-3 rounded-lg border border-biq-border-subtle bg-biq-surface-1/50 px-4 py-3"
           >
-            <span className="text-lg flex-shrink-0" aria-hidden="true">{d.icon}</span>
+            <span className="flex-shrink-0 mt-0.5" aria-hidden="true">{d.icon}</span>
             <p className="text-sm text-biq-text-secondary leading-snug">{d.text}</p>
           </div>
         ))}

--- a/src/components/golden-flows/VerticalHero.tsx
+++ b/src/components/golden-flows/VerticalHero.tsx
@@ -29,11 +29,10 @@ export default function VerticalHero({
   const delta = latest.score - first.score;
   const improving = delta >= 0;
 
-  // Vertical-specific headline: use hookMetrics question or narrative headline
-  const headline =
-    hookMetrics?.discrepancy_headline ??
-    narrative?.headline_finding ??
-    `${verticalName} data reliability`;
+  // Confidence-first: frame the headline as what BayesIQ achieved, not what was broken
+  const headline = narrative?.with_bayesiq
+    ? `${verticalName}: ${narrative.headline_finding}`
+    : hookMetrics?.discrepancy_headline ?? `${verticalName} data reliability`;
 
   // Business framing
   const framing = narrative?.with_bayesiq ?? null;
@@ -69,7 +68,7 @@ export default function VerticalHero({
 
         {/* Headline + framing */}
         <div className="min-w-0 flex-1">
-          <h1 className="text-xl font-bold tracking-tight text-biq-text-primary sm:text-2xl leading-snug">
+          <h1 className="text-2xl font-bold tracking-tight text-biq-text-primary sm:text-3xl leading-snug">
             {headline}
           </h1>
           {framing && (

--- a/src/components/golden-flows/WhyThisMatters.tsx
+++ b/src/components/golden-flows/WhyThisMatters.tsx
@@ -1,0 +1,113 @@
+import type { BoardReportRisk } from "@/lib/golden-flows";
+
+interface Props {
+  risks: BoardReportRisk[];
+}
+
+function SeverityIcon({ severity }: { severity: string }) {
+  switch (severity) {
+    case "high":
+      return (
+        <svg
+          className="h-5 w-5 text-biq-status-error flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+          />
+        </svg>
+      );
+    case "medium":
+      return (
+        <svg
+          className="h-5 w-5 text-biq-status-warning flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"
+          />
+        </svg>
+      );
+    default:
+      return (
+        <svg
+          className="h-5 w-5 text-biq-status-success flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      );
+  }
+}
+
+function severityBadge(severity: string): string {
+  switch (severity) {
+    case "high":
+      return "bg-biq-status-error-subtle text-biq-status-error";
+    case "medium":
+      return "bg-biq-status-warning-subtle text-biq-status-warning";
+    default:
+      return "bg-biq-status-success-subtle text-biq-status-success";
+  }
+}
+
+export default function WhyThisMatters({ risks }: Props) {
+  if (!risks || risks.length === 0) return null;
+
+  const displayed = risks.slice(0, 3);
+
+  return (
+    <section className="mt-12" data-testid="why-this-matters">
+      <h2 className="text-lg font-bold tracking-tight text-biq-text-primary mb-4">
+        Why this matters
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {displayed.map((risk) => (
+          <div
+            key={risk.title}
+            className="rounded-xl border border-biq-border bg-white p-5 shadow-sm"
+          >
+            <div className="flex items-start gap-3">
+              <SeverityIcon severity={risk.severity} />
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 mb-2">
+                  <h3 className="text-sm font-semibold text-biq-text-primary leading-snug">
+                    {risk.title}
+                  </h3>
+                  <span
+                    className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${severityBadge(risk.severity)}`}
+                  >
+                    {risk.severity}
+                  </span>
+                </div>
+                <p className="text-xs text-biq-text-secondary leading-relaxed">
+                  {risk.business_impact}
+                </p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Wire RemediationArc, WhyThisMatters, and BayesIQDifference sections below the tabs on golden flows vertical pages
- Create WhyThisMatters component — consequence callout cards from board report top risks with severity-aware SVG icons
- Upgrade VerticalHero headline to confidence-first framing
- Replace emoji icons with professional SVG icons in BayesIQDifference

## Details
Addresses golden-flows-cleanup.md PR 4c (narrative sections below tabs) and PR 4d (copy pass). The vertical page now has a full narrative spine: Hero → Reality Reveal → Tabs → Deliverables → **Why This Matters → Remediation Arc → BayesIQ Difference** → CTA.

## Test plan
- [x] `npm run build` passes (all 5 verticals)
- [x] `npm test` passes (126 E2E tests)

Part of #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)