### PR TITLE
Migrate dark sections to DS dark surface tokens

### DIFF
--- a/src/app/assessment/page.tsx
+++ b/src/app/assessment/page.tsx
@@ -120,7 +120,7 @@ export default function AssessmentPage() {
             {AUDIT_DIMENSIONS.map((dim) => (
               <div key={dim.label} className="flex gap-4">
                 <span
-                  className="mt-1 h-2 w-2 shrink-0 rounded-full bg-bayesiq-900"
+                  className="mt-1 h-2 w-2 shrink-0 rounded-full bg-biq-dark-surface-1"
                   aria-hidden="true"
                 />
                 <div>
@@ -165,12 +165,12 @@ export default function AssessmentPage() {
       </section>
 
       {/* Bottom CTA */}
-      <section className="border-t border-biq-border bg-bayesiq-900 px-6 py-20 text-center">
+      <section className="border-t border-biq-border bg-biq-dark-surface-1 px-6 py-20 text-center">
         <div className="mx-auto max-w-2xl">
           <h2 className="text-2xl font-bold tracking-tight text-white">
             Want a real answer, not a directional one?
           </h2>
-          <p className="mt-4 text-base text-bayesiq-300">
+          <p className="mt-4 text-base text-biq-dark-text-primary">
             A BayesIQ audit examines your actual telemetry, pipelines, and
             metric definitions — and gives you a severity-ranked fix plan in
             under two weeks.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,22 +24,6 @@
 
 /* Step 4: Site-specific theme additions */
 @theme {
-  /* Gray scale: retained for dark-section contexts (buttons, CTA,
-     platform page, Header, Footer, GovernanceChain dark theme).
-     These are site-specific — not part of the centralized design system.
-     TODO: migrate dark sections to a DS dark-surface token set. */
-  --color-bayesiq-950: #0a0f1a;
-  --color-bayesiq-900: #111827;
-  --color-bayesiq-800: #1f2937;
-  --color-bayesiq-700: #374151;
-  --color-bayesiq-600: #4b5563;
-  --color-bayesiq-500: #6b7280;
-  --color-bayesiq-400: #9ca3af;
-  --color-bayesiq-300: #d1d5db;
-  --color-bayesiq-200: #e5e7eb;
-  --color-bayesiq-100: #f3f4f6;
-  --color-bayesiq-50: #f9fafb;
-
   /* Accent aliases (resolve to DS primary) */
   --color-accent: var(--biq-color-primary);
   --color-accent-dark: var(--biq-color-primary-hover);
@@ -74,12 +58,3 @@ body {
   outline-offset: 2px;
 }
 
-/* Dark mode scoped variables for platform page */
-.dark {
-  --dark-bg: var(--color-bayesiq-950);
-  --dark-bg-subtle: var(--color-bayesiq-900);
-  --dark-text: var(--color-bayesiq-50);
-  --dark-text-muted: var(--color-bayesiq-400);
-  --dark-border: var(--color-bayesiq-700);
-  --dark-accent: #60a5fa;
-}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -89,11 +89,11 @@ export default function HomePage() {
       {/* ──────────────────────────────────────────────
           Section 4: Governance Chain
           ──────────────────────────────────────────── */}
-      <section className="bg-bayesiq-900 px-6 py-20 md:py-24">
+      <section className="bg-biq-dark-surface-1 px-6 py-20 md:py-24">
         <SectionReveal>
           <div className="mx-auto max-w-3xl text-center">
             <GovernanceChain variant="simple" theme="light" />
-            <p className="mt-10 text-lg leading-relaxed text-bayesiq-300">
+            <p className="mt-10 text-lg leading-relaxed text-biq-dark-text-primary">
               Every finding reviewed. Every decision attributed.
               <br className="hidden sm:inline" />
               Every transition evidence-backed.

--- a/src/app/platform/page.tsx
+++ b/src/app/platform/page.tsx
@@ -48,7 +48,7 @@ const notList = [
 
 export default function PlatformPage() {
   return (
-    <div className="dark bg-bayesiq-950">
+    <div className="bg-biq-dark-surface-0">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(platformJsonLd) }}
@@ -60,10 +60,10 @@ export default function PlatformPage() {
           <h1 className="font-display text-4xl font-bold leading-tight tracking-tight text-white md:text-5xl lg:text-6xl">
             AI outputs are increasingly consequential.
           </h1>
-          <p className="mt-6 font-display text-2xl font-medium text-[var(--dark-accent)] md:text-3xl">
+          <p className="mt-6 font-display text-2xl font-medium text-accent md:text-3xl">
             Nobody can prove who approved what, or why.
           </p>
-          <p className="mx-auto mt-8 max-w-2xl text-base leading-relaxed text-bayesiq-400">
+          <p className="mx-auto mt-8 max-w-2xl text-base leading-relaxed text-biq-dark-text-secondary">
             Models generate insights, recommendations, and actions at a pace
             that outstrips any human review process. The gap between what AI
             produces and what a responsible organization can defend is growing
@@ -73,16 +73,16 @@ export default function PlatformPage() {
       </PlatformSection>
 
       {/* Section 2: The Thesis */}
-      <PlatformSection className="border-t border-bayesiq-800 bg-bayesiq-900">
+      <PlatformSection className="border-t border-biq-dark-border bg-biq-dark-surface-1">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-xs font-semibold uppercase tracking-wider text-bayesiq-500">
+          <p className="text-xs font-semibold uppercase tracking-wider text-biq-dark-text-secondary">
             The thesis
           </p>
           <h2 className="mt-4 font-display text-2xl font-bold leading-snug text-white md:text-3xl">
             BayesIQ is the governance layer that produces an auditable chain
             from raw output to approved deliverable.
           </h2>
-          <p className="mt-6 text-base leading-relaxed text-bayesiq-300">
+          <p className="mt-6 text-base leading-relaxed text-biq-dark-text-primary">
             Every finding reviewed. Every decision attributed. Every transition
             evidence-backed. Not a policy document -- a running system that
             enforces the chain in real time.
@@ -93,16 +93,16 @@ export default function PlatformPage() {
       {/* Section 3: Three Truth Layers */}
       <PlatformSection
         id="truth-layers"
-        className="border-t border-bayesiq-800"
+        className="border-t border-biq-dark-border"
       >
         <div className="text-center">
-          <p className="text-xs font-semibold uppercase tracking-wider text-bayesiq-500">
+          <p className="text-xs font-semibold uppercase tracking-wider text-biq-dark-text-secondary">
             The architecture
           </p>
           <h2 className="mt-4 font-display text-2xl font-bold text-white md:text-3xl">
             Three layers of truth
           </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-bayesiq-400">
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-biq-dark-text-secondary">
             Every piece of information moves through three distinct layers.
             Nothing reaches operational state without explicit human acceptance.
             The layers are the invariant -- they apply to every engagement, every
@@ -113,15 +113,15 @@ export default function PlatformPage() {
       </PlatformSection>
 
       {/* Section 4: Executor-Neutral */}
-      <PlatformSection className="border-t border-bayesiq-800 bg-bayesiq-900">
+      <PlatformSection className="border-t border-biq-dark-border bg-biq-dark-surface-1">
         <div className="text-center">
-          <p className="text-xs font-semibold uppercase tracking-wider text-bayesiq-500">
+          <p className="text-xs font-semibold uppercase tracking-wider text-biq-dark-text-secondary">
             Executor-neutral
           </p>
           <h2 className="mt-4 font-display text-2xl font-bold text-white md:text-3xl">
             The contract is portable. The audit trail is the product.
           </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-bayesiq-400">
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-biq-dark-text-secondary">
             BayesIQ works with any execution engine -- your AI pipeline, a
             coding assistant, a contractor, a CI job. The work is defined in
             portable, human-readable contracts. Any compliant engine can consume
@@ -133,15 +133,15 @@ export default function PlatformPage() {
       </PlatformSection>
 
       {/* Section 5: What Makes This Different */}
-      <PlatformSection className="border-t border-bayesiq-800">
+      <PlatformSection className="border-t border-biq-dark-border">
         <div className="text-center">
-          <p className="text-xs font-semibold uppercase tracking-wider text-bayesiq-500">
+          <p className="text-xs font-semibold uppercase tracking-wider text-biq-dark-text-secondary">
             Differentiation
           </p>
           <h2 className="mt-4 font-display text-2xl font-bold text-white md:text-3xl">
             What this is not
           </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-bayesiq-400">
+          <p className="mx-auto mt-4 max-w-2xl text-sm leading-relaxed text-biq-dark-text-secondary">
             The only system that joins ingestion, extraction, triage, governed
             transitions, and evidence-backed completion in one loop.
           </p>
@@ -150,12 +150,12 @@ export default function PlatformPage() {
           {notList.map((item) => (
             <div
               key={item.label}
-              className="rounded-xl border border-bayesiq-700 bg-bayesiq-900 p-6"
+              className="rounded-xl border border-biq-dark-border bg-biq-dark-surface-1 p-6"
             >
-              <h3 className="text-sm font-bold text-[var(--dark-accent)]">
+              <h3 className="text-sm font-bold text-accent">
                 {item.label}
               </h3>
-              <p className="mt-3 text-sm leading-relaxed text-bayesiq-400">
+              <p className="mt-3 text-sm leading-relaxed text-biq-dark-text-secondary">
                 {item.detail}
               </p>
             </div>
@@ -164,20 +164,20 @@ export default function PlatformPage() {
       </PlatformSection>
 
       {/* Section 6: Built By a Consultant */}
-      <PlatformSection className="border-t border-bayesiq-800 bg-bayesiq-900">
+      <PlatformSection className="border-t border-biq-dark-border bg-biq-dark-surface-1">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-xs font-semibold uppercase tracking-wider text-bayesiq-500">
+          <p className="text-xs font-semibold uppercase tracking-wider text-biq-dark-text-secondary">
             Origin
           </p>
           <h2 className="mt-4 font-display text-2xl font-bold text-white md:text-3xl">
             Built by a consultant, for consultants
           </h2>
-          <p className="mt-6 text-base leading-relaxed text-bayesiq-300">
+          <p className="mt-6 text-base leading-relaxed text-biq-dark-text-primary">
             We built this because we needed it. Managing multiple client
             engagements with scattered emails, half-tracked commitments, and no
             single surface to prove what was promised and what was delivered.
           </p>
-          <p className="mt-4 text-base leading-relaxed text-bayesiq-300">
+          <p className="mt-4 text-base leading-relaxed text-biq-dark-text-primary">
             One place to track engagements. One governed surface for client
             interactions. Contracts with evidence-backed completion -- so when a
             client asks &ldquo;what happened?&rdquo; you have the answer, not a
@@ -187,15 +187,15 @@ export default function PlatformPage() {
       </PlatformSection>
 
       {/* Section 7: Regulated-Ready */}
-      <PlatformSection className="border-t border-bayesiq-800">
+      <PlatformSection className="border-t border-biq-dark-border">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-xs font-semibold uppercase tracking-wider text-bayesiq-500">
+          <p className="text-xs font-semibold uppercase tracking-wider text-biq-dark-text-secondary">
             Compliance
           </p>
           <h2 className="mt-4 font-display text-2xl font-bold text-white md:text-3xl">
             Regulation built in, not bolted on
           </h2>
-          <p className="mt-6 text-base leading-relaxed text-bayesiq-300">
+          <p className="mt-6 text-base leading-relaxed text-biq-dark-text-primary">
             The same governance chain that makes day-to-day operations
             trustworthy also satisfies regulated environments. Every state
             transition carries an attestation. Every decision links to its
@@ -210,7 +210,7 @@ export default function PlatformPage() {
             ].map((badge) => (
               <span
                 key={badge}
-                className="rounded-full border border-bayesiq-600 px-4 py-1.5 text-xs font-medium text-bayesiq-300"
+                className="rounded-full border border-biq-dark-border px-4 py-1.5 text-xs font-medium text-biq-dark-text-primary"
               >
                 {badge}
               </span>
@@ -220,12 +220,12 @@ export default function PlatformPage() {
       </PlatformSection>
 
       {/* Section 8: CTA */}
-      <PlatformSection className="border-t border-bayesiq-800 bg-bayesiq-900">
+      <PlatformSection className="border-t border-biq-dark-border bg-biq-dark-surface-1">
         <div className="mx-auto max-w-2xl text-center">
           <h2 className="font-display text-3xl font-bold text-white md:text-4xl">
             See it in action
           </h2>
-          <p className="mt-4 text-base leading-relaxed text-bayesiq-300">
+          <p className="mt-4 text-base leading-relaxed text-biq-dark-text-primary">
             Explore a live engagement walkthrough, or talk to us about how the
             platform fits your operation.
           </p>

--- a/src/components/CTA.tsx
+++ b/src/components/CTA.tsx
@@ -14,11 +14,11 @@ export default function CTA({
   href = "/contact",
 }: CTAProps) {
   return (
-    <section className="bg-bayesiq-900 px-6 py-20 text-center">
+    <section className="bg-biq-dark-surface-1 px-6 py-20 text-center">
       <div className="mx-auto max-w-2xl">
         <h2 className="font-display text-3xl font-bold tracking-tight text-white">{headline}</h2>
         {description && (
-          <p className="mt-4 text-lg text-bayesiq-300">{description}</p>
+          <p className="mt-4 text-lg text-biq-dark-text-primary">{description}</p>
         )}
         <Link
           href={href}

--- a/src/components/GovernanceChain.tsx
+++ b/src/components/GovernanceChain.tsx
@@ -29,12 +29,12 @@ export default function GovernanceChain({
 
   // Theme-aware colors
   const nodeFill =
-    theme === "light" ? "var(--color-bayesiq-200)" : "var(--color-biq-text-primary)";
+    theme === "light" ? "var(--biq-color-dark-text-secondary)" : "var(--color-biq-text-primary)";
   const nodeText = theme === "light" ? "var(--color-biq-text-primary)" : "white";
   const connectorColor =
-    theme === "light" ? "var(--color-bayesiq-500)" : "var(--color-biq-text-muted)";
+    theme === "light" ? "var(--biq-color-dark-text-secondary)" : "var(--color-biq-text-muted)";
   const labelColor =
-    theme === "light" ? "var(--color-bayesiq-300)" : "var(--color-biq-text-secondary)";
+    theme === "light" ? "var(--biq-color-dark-text-primary)" : "var(--color-biq-text-secondary)";
 
   // Horizontal layout dimensions
   const svgWidth = (nodes.length - 1) * nodeSpacing + nodeRadius * 2 + 40;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,7 +32,7 @@ export default function Header() {
           ))}
           <Link
             href="/contact"
-            className="rounded-lg bg-bayesiq-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
+            className="rounded-lg bg-biq-dark-surface-1 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-biq-dark-surface-2"
           >
             Get in Touch
           </Link>
@@ -69,7 +69,7 @@ export default function Header() {
           ))}
           <Link
             href="/contact"
-            className="mt-2 block rounded-lg bg-bayesiq-900 px-4 py-2 text-center text-sm font-medium text-white"
+            className="mt-2 block rounded-lg bg-biq-dark-surface-1 px-4 py-2 text-center text-sm font-medium text-white"
             onClick={() => setMenuOpen(false)}
           >
             Get in Touch

--- a/src/components/PathCard.tsx
+++ b/src/components/PathCard.tsx
@@ -44,7 +44,7 @@ export default function PathCard({
       <div className="mt-8">
         <Link
           href={href}
-          className="inline-block rounded-lg bg-bayesiq-900 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-bayesiq-800"
+          className="inline-block rounded-lg bg-biq-dark-surface-1 px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-biq-dark-surface-2"
         >
           {cta}
         </Link>

--- a/src/components/assessment/Progress.tsx
+++ b/src/components/assessment/Progress.tsx
@@ -29,7 +29,7 @@ export default function Progress({ current, total }: ProgressProps) {
         className="h-1.5 w-full overflow-hidden rounded-full bg-biq-surface-2"
       >
         <div
-          className="h-full rounded-full bg-bayesiq-900 transition-all duration-300"
+          className="h-full rounded-full bg-biq-dark-surface-1 transition-all duration-300"
           style={{ width: `${percent}%` }}
         />
       </div>

--- a/src/components/assessment/QuestionCard.tsx
+++ b/src/components/assessment/QuestionCard.tsx
@@ -35,7 +35,7 @@ export default function QuestionCard({
               className={[
                 "flex min-h-12 cursor-pointer items-start gap-4 rounded-lg border px-4 py-3 text-sm transition-colors",
                 isSelected
-                  ? "border-bayesiq-900 bg-biq-surface-1 text-biq-text-primary"
+                  ? "border-biq-dark-surface-1 bg-biq-surface-1 text-biq-text-primary"
                   : "border-biq-border text-biq-text-secondary hover:border-biq-text-muted hover:bg-biq-surface-1",
               ].join(" ")}
             >
@@ -46,7 +46,7 @@ export default function QuestionCard({
                 value={idx}
                 checked={isSelected}
                 onChange={() => onSelect(idx)}
-                className="mt-0.5 h-4 w-4 shrink-0 accent-bayesiq-900 focus-visible:ring-2 focus-visible:ring-bayesiq-900 focus-visible:ring-offset-2"
+                className="mt-0.5 h-4 w-4 shrink-0 accent-biq-dark-surface-1 focus-visible:ring-2 focus-visible:ring-biq-dark-surface-1 focus-visible:ring-offset-2"
               />
               <span className="leading-relaxed">{choice.text}</span>
             </label>

--- a/src/components/assessment/ScoreReveal.tsx
+++ b/src/components/assessment/ScoreReveal.tsx
@@ -79,7 +79,7 @@ export default function ScoreReveal({ result }: ScoreRevealProps) {
             transition={{ duration: 0.2 }}
             className="flex flex-col items-center justify-center py-20"
           >
-            <div className="h-8 w-8 animate-spin rounded-full border-2 border-biq-border border-t-bayesiq-900" />
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-biq-border border-t-biq-dark-surface-1" />
             <p className="mt-4 text-sm font-medium text-biq-text-muted">
               Calculating your score...
             </p>

--- a/src/components/assessment/StepDots.tsx
+++ b/src/components/assessment/StepDots.tsx
@@ -26,9 +26,9 @@ export default function StepDots({ current, total }: StepDotsProps) {
               className={[
                 "block h-2.5 w-2.5 rounded-full transition-all duration-300",
                 isCompleted
-                  ? "bg-bayesiq-900"
+                  ? "bg-biq-dark-surface-1"
                   : isCurrent
-                    ? "bg-bayesiq-900 animate-pulse"
+                    ? "bg-biq-dark-surface-1 animate-pulse"
                     : "bg-biq-surface-2",
               ].join(" ")}
             />

--- a/src/components/consulting/EngagementTiers.tsx
+++ b/src/components/consulting/EngagementTiers.tsx
@@ -68,12 +68,12 @@ export default function EngagementTiers() {
           key={tier.name}
           className={`flex flex-col rounded-xl border p-6 ${
             tier.highlighted
-              ? "border-bayesiq-900 ring-1 ring-bayesiq-900"
+              ? "border-biq-dark-surface-1 ring-1 ring-biq-dark-surface-1"
               : "border-biq-border"
           }`}
         >
           {tier.highlighted && (
-            <span className="mb-3 inline-block w-fit rounded-full bg-bayesiq-900 px-3 py-0.5 text-xs font-medium text-white">
+            <span className="mb-3 inline-block w-fit rounded-full bg-biq-dark-surface-1 px-3 py-0.5 text-xs font-medium text-white">
               Most Popular
             </span>
           )}

--- a/src/components/consulting/IndustryTabs.tsx
+++ b/src/components/consulting/IndustryTabs.tsx
@@ -100,7 +100,7 @@ function IndustryTabsInner() {
             onKeyDown={(e) => handleKeyDown(e, index)}
             className={`shrink-0 border-b-2 px-4 py-3 text-sm font-medium transition-colors ${
               vertical.id === activeId
-                ? "border-bayesiq-900 text-biq-text-primary"
+                ? "border-biq-dark-surface-1 text-biq-text-primary"
                 : "border-transparent text-biq-text-muted hover:text-biq-text-secondary"
             }`}
           >

--- a/src/components/consulting/PipelineSteps.tsx
+++ b/src/components/consulting/PipelineSteps.tsx
@@ -68,7 +68,7 @@ export default function PipelineSteps({
           <li key={step.number} className="relative md:pl-14">
             {/* Step number circle */}
             <div className="mb-2 flex items-center gap-3 md:absolute md:left-0 md:top-0 md:mb-0">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-bayesiq-900 font-mono text-sm font-medium text-white">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-biq-dark-surface-1 font-mono text-sm font-medium text-white">
                 {step.number}
               </span>
               <h3 className="font-display text-lg font-semibold text-biq-text-primary md:hidden">

--- a/src/components/golden-flows/GoldenFlowsCTA.tsx
+++ b/src/components/golden-flows/GoldenFlowsCTA.tsx
@@ -17,12 +17,12 @@ export default function GoldenFlowsCTA({
   return (
     <div className="mt-16 space-y-0">
       {/* Section 1 — Diagnostic Entry Point */}
-      <section className="rounded-t-xl bg-bayesiq-900 px-6 py-14 text-center">
+      <section className="rounded-t-xl bg-biq-dark-surface-1 px-6 py-14 text-center">
         <div className="mx-auto max-w-2xl">
           <h2 className="text-2xl font-bold tracking-tight text-white sm:text-3xl">
             {diagnosticHeadline}
           </h2>
-          <p className="mt-4 text-lg text-bayesiq-300">
+          <p className="mt-4 text-lg text-biq-dark-text-primary">
             A focused $7,500 engagement. We audit your{" "}
             {vertical ? vertical.toLowerCase() : ""} data, score your metrics,
             and deliver a remediation roadmap in 2 weeks.
@@ -71,7 +71,7 @@ export default function GoldenFlowsCTA({
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => trackCtaClick("book_session", vertical || "unknown")}
-            className="mt-8 inline-block rounded-lg border border-bayesiq-900 bg-white px-6 py-3 text-sm font-medium text-biq-text-primary transition-colors hover:bg-biq-surface-1"
+            className="mt-8 inline-block rounded-lg border border-biq-dark-surface-1 bg-white px-6 py-3 text-sm font-medium text-biq-text-primary transition-colors hover:bg-biq-surface-1"
           >
             Book a call
           </a>

--- a/src/components/golden-flows/ScoreTrajectory.tsx
+++ b/src/components/golden-flows/ScoreTrajectory.tsx
@@ -111,7 +111,7 @@ export default function ScoreTrajectory({ snapshots, size = "compact" }: Props) 
               x={x(i)}
               y={y(snap.score) - 8}
               textAnchor="middle"
-              className="fill-bayesiq-800"
+              className="fill-biq-dark-surface-2"
               fontSize={11}
               fontWeight={600}
             >

--- a/src/components/golden-flows/VerticalTabs.tsx
+++ b/src/components/golden-flows/VerticalTabs.tsx
@@ -62,7 +62,7 @@ export default function VerticalTabs({
               onClick={() => handleTabClick(tab.key)}
               className={`px-5 py-3 text-sm font-medium transition-colors ${
                 activeTab === tab.key
-                  ? "border-b-2 border-bayesiq-900 text-biq-text-primary"
+                  ? "border-b-2 border-biq-dark-surface-1 text-biq-text-primary"
                   : "text-biq-text-muted hover:text-biq-text-secondary"
               }`}
             >

--- a/src/components/platform/GovernanceChainExpanded.tsx
+++ b/src/components/platform/GovernanceChainExpanded.tsx
@@ -108,10 +108,10 @@ export default function GovernanceChainExpanded() {
           >
             <motion.div
               variants={shouldReduceMotion ? undefined : itemVariants}
-              className="flex h-24 w-40 flex-col items-center justify-center rounded-lg border border-bayesiq-600 bg-bayesiq-900 text-center"
+              className="flex h-24 w-40 flex-col items-center justify-center rounded-lg border border-biq-dark-border bg-biq-dark-surface-1 text-center"
             >
               <span className="text-sm font-bold text-white">{step.label}</span>
-              <span className="mt-1 text-xs text-bayesiq-400">{step.sub}</span>
+              <span className="mt-1 text-xs text-biq-dark-text-secondary">{step.sub}</span>
             </motion.div>
             {i < chainSteps.length - 1 && (
               <motion.div
@@ -121,7 +121,7 @@ export default function GovernanceChainExpanded() {
               >
                 {/* Vertical arrow on mobile, horizontal on sm+ */}
                 <svg
-                  className="h-6 w-6 rotate-90 text-bayesiq-500 sm:rotate-0"
+                  className="h-6 w-6 rotate-90 text-biq-dark-text-secondary sm:rotate-0"
                   fill="none"
                   viewBox="0 0 24 24"
                   strokeWidth={1.5}
@@ -144,7 +144,7 @@ export default function GovernanceChainExpanded() {
           aria-hidden="true"
         >
           <svg
-            className="h-6 w-6 text-[var(--dark-accent)]"
+            className="h-6 w-6 text-accent"
             fill="none"
             viewBox="0 0 24 24"
             strokeWidth={1.5}
@@ -171,13 +171,13 @@ export default function GovernanceChainExpanded() {
           <motion.div
             key={path.label}
             variants={shouldReduceMotion ? undefined : itemVariants}
-            className="rounded-xl border border-bayesiq-700 bg-bayesiq-900 p-6 text-center"
+            className="rounded-xl border border-biq-dark-border bg-biq-dark-surface-1 p-6 text-center"
           >
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-bayesiq-800 text-[var(--dark-accent)]">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-biq-dark-surface-2 text-accent">
               {path.icon}
             </div>
             <h4 className="mt-4 text-sm font-bold text-white">{path.label}</h4>
-            <p className="mt-2 text-xs leading-relaxed text-bayesiq-400">
+            <p className="mt-2 text-xs leading-relaxed text-biq-dark-text-secondary">
               {path.description}
             </p>
           </motion.div>

--- a/src/components/platform/PlatformCTA.tsx
+++ b/src/components/platform/PlatformCTA.tsx
@@ -16,13 +16,13 @@ export default function PlatformCTA() {
     >
       <Link
         href="/consulting/explore"
-        className="inline-block rounded-lg bg-white px-8 py-3.5 text-sm font-semibold text-bayesiq-900 transition-colors hover:bg-bayesiq-100"
+        className="inline-block rounded-lg bg-white px-8 py-3.5 text-sm font-semibold text-biq-text-primary transition-colors hover:bg-biq-surface-2"
       >
         See it in action
       </Link>
       <Link
         href="/contact"
-        className="inline-block rounded-lg border border-bayesiq-500 px-8 py-3.5 text-sm font-semibold text-bayesiq-300 transition-colors hover:border-bayesiq-300 hover:text-white"
+        className="inline-block rounded-lg border border-biq-dark-text-secondary px-8 py-3.5 text-sm font-semibold text-biq-dark-text-primary transition-colors hover:border-biq-dark-text-primary hover:text-white"
       >
         Talk to us about the platform
       </Link>

--- a/src/components/platform/ThreeTruthLayers.tsx
+++ b/src/components/platform/ThreeTruthLayers.tsx
@@ -9,9 +9,9 @@ const layers = [
     subtitle: "Immutable evidence",
     description:
       "No summaries, no interpretations. Just the record. Pipeline outputs, test results, call transcripts, emails -- the ground truth your decisions rest on.",
-    color: "border-bayesiq-600",
-    bg: "bg-bayesiq-900",
-    accent: "text-bayesiq-400",
+    color: "border-biq-dark-border",
+    bg: "bg-biq-dark-surface-1",
+    accent: "text-biq-dark-text-secondary",
     glow: "shadow-[0_0_24px_rgba(59,130,246,0.08)]",
   },
   {
@@ -20,9 +20,9 @@ const layers = [
     subtitle: "Structured output",
     description:
       "AI-generated proposals, extracted tasks, priority assessments, and summaries. Clearly labeled as interpretation, not fact. Never auto-promoted to operational state.",
-    color: "border-bayesiq-500",
-    bg: "bg-bayesiq-800",
-    accent: "text-bayesiq-300",
+    color: "border-biq-dark-text-secondary",
+    bg: "bg-biq-dark-surface-2",
+    accent: "text-biq-dark-text-primary",
     glow: "shadow-[0_0_24px_rgba(59,130,246,0.12)]",
   },
   {
@@ -32,8 +32,8 @@ const layers = [
     description:
       "The only layer that drives dashboards, deadlines, and work state. Nothing reaches this layer without explicit human acceptance. This is your single source of governed truth.",
     color: "border-accent",
-    bg: "bg-bayesiq-800",
-    accent: "text-[var(--dark-accent)]",
+    bg: "bg-biq-dark-surface-2",
+    accent: "text-accent",
     glow: "shadow-[0_0_32px_rgba(96,165,250,0.15)]",
   },
 ];
@@ -82,7 +82,7 @@ export default function ThreeTruthLayers() {
           {i > 0 && (
             <motion.div
               variants={shouldReduceMotion ? undefined : flowVariants}
-              className="h-10 w-px origin-top bg-gradient-to-b from-bayesiq-600 to-bayesiq-700"
+              className="h-10 w-px origin-top bg-gradient-to-b from-biq-dark-border to-biq-dark-border"
               aria-hidden="true"
             />
           )}
@@ -100,10 +100,10 @@ export default function ThreeTruthLayers() {
             <h3 className="mt-2 font-display text-xl font-bold text-white md:text-2xl">
               {layer.title}
             </h3>
-            <p className="mt-1 text-sm font-medium text-bayesiq-300">
+            <p className="mt-1 text-sm font-medium text-biq-dark-text-primary">
               {layer.subtitle}
             </p>
-            <p className="mt-3 text-sm leading-relaxed text-bayesiq-400">
+            <p className="mt-3 text-sm leading-relaxed text-biq-dark-text-secondary">
               {layer.description}
             </p>
           </motion.div>
@@ -116,8 +116,8 @@ export default function ThreeTruthLayers() {
         className="mt-1 flex flex-col items-center"
         aria-hidden="true"
       >
-        <div className="h-8 w-px bg-gradient-to-b from-bayesiq-600 to-transparent" />
-        <div className="mt-1 h-2 w-2 rounded-full bg-[var(--dark-accent)]" />
+        <div className="h-8 w-px bg-gradient-to-b from-biq-dark-border to-transparent" />
+        <div className="mt-1 h-2 w-2 rounded-full bg-accent" />
       </motion.div>
     </motion.div>
   );

--- a/src/components/platform/__tests__/platform-components.test.tsx
+++ b/src/components/platform/__tests__/platform-components.test.tsx
@@ -45,12 +45,12 @@ describe("PlatformSection", () => {
 
   it("applies custom className", () => {
     const { container } = render(
-      <PlatformSection className="bg-bayesiq-900">
+      <PlatformSection className="bg-biq-dark-surface-1">
         <p>Content</p>
       </PlatformSection>
     );
     const section = container.querySelector("section");
-    expect(section?.className).toContain("bg-bayesiq-900");
+    expect(section?.className).toContain("bg-biq-dark-surface-1");
   });
 
   it("applies id when provided", () => {

--- a/src/vendor/biq/tailwind-v4-theme.css
+++ b/src/vendor/biq/tailwind-v4-theme.css
@@ -35,6 +35,12 @@
   --color-biq-status-error-subtle: var(--biq-color-status-error-subtle);
   --color-biq-status-info: var(--biq-color-status-info);
   --color-biq-status-info-subtle: var(--biq-color-status-info-subtle);
+  --color-biq-dark-surface-0: var(--biq-color-dark-surface-0);
+  --color-biq-dark-surface-1: var(--biq-color-dark-surface-1);
+  --color-biq-dark-surface-2: var(--biq-color-dark-surface-2);
+  --color-biq-dark-text-primary: var(--biq-color-dark-text-primary);
+  --color-biq-dark-text-secondary: var(--biq-color-dark-text-secondary);
+  --color-biq-dark-border: var(--biq-color-dark-border);
 
   /* ── Font Families ──
    * Generates: font-biq-sans, font-biq-serif, font-biq-mono

--- a/src/vendor/biq/tokens.css
+++ b/src/vendor/biq/tokens.css
@@ -26,6 +26,12 @@
   --biq-color-status-error-subtle: #fee2e2;
   --biq-color-status-info: #1a73e8;
   --biq-color-status-info-subtle: #dde8f8;
+  --biq-color-dark-surface-0: #0a0f1a;
+  --biq-color-dark-surface-1: #0f172a;
+  --biq-color-dark-surface-2: #1e293b;
+  --biq-color-dark-text-primary: #f8fafc;
+  --biq-color-dark-text-secondary: #94a3b8;
+  --biq-color-dark-border: #1e293b;
 
   /* ── Typography ── */
   /* ── Spacing ── */
@@ -80,4 +86,10 @@
   --biq-breakpoint-md: 768px;
   --biq-breakpoint-lg: 1024px;
   --biq-breakpoint-xl: 1280px;
+  --biq-container-max-width: 1200px;
+  --biq-container-padding-x: 16px;
+  --biq-container-padding-x-md: 24px;
+  --biq-container-padding-x-lg: 32px;
+  --biq-section-padding-y: 48px;
+  --biq-section-padding-y-md: 64px;
 }


### PR DESCRIPTION
## Summary
- Replace all hand-rolled `bayesiq-{50..950}` gray scale classes with semantic `biq-dark-*` tokens from the design system
- Sync vendor tokens + Tailwind theme mappings via vendor-sync.sh
- Remove 11-value gray scale and `.dark` block from globals.css
- 24 files migrated, zero `bayesiq-N` references remaining

## Token mapping
| Old | New |
|-----|-----|
| `bg-bayesiq-950` | `bg-biq-dark-surface-0` |
| `bg-bayesiq-900` | `bg-biq-dark-surface-1` |
| `text-bayesiq-300` | `text-biq-dark-text-primary` |
| `text-bayesiq-400/500` | `text-biq-dark-text-secondary` |
| `border-bayesiq-700/800` | `border-biq-dark-border` |

## Test plan
- [x] `npm run build` passes (all routes)
- [x] Zero `bayesiq-N` class references remaining in src/

Fixes #77, #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)