### PR TITLE
Fix email domain: bayesiq.com → bayes-iq.com

### DIFF
--- a/docs/product/privacy.md
+++ b/docs/product/privacy.md
@@ -57,10 +57,10 @@ Contact form submissions are retained for as long as necessary to respond to you
 
 ## Your rights
 
-You have the right to request access to, correction of, or deletion of your personal data. To make a request, contact us at privacy@bayesiq.com.
+You have the right to request access to, correction of, or deletion of your personal data. To make a request, contact us at privacy@bayes-iq.com.
 
 ---
 
 ## Contact
 
-Questions about this privacy policy? Email us at privacy@bayesiq.com.
+Questions about this privacy policy? Email us at privacy@bayes-iq.com.

--- a/docs/product/terms.md
+++ b/docs/product/terms.md
@@ -57,4 +57,4 @@ These terms are governed by applicable law. Specific jurisdiction will be establ
 
 ## Contact
 
-Questions about these terms? Email us at hello@bayesiq.com or use our contact form at https://bayesiq.com/contact.
+Questions about these terms? Email us at hello@bayes-iq.com or use our contact form at https://bayes-iq.com/contact.

--- a/src/app/contact/actions.ts
+++ b/src/app/contact/actions.ts
@@ -7,7 +7,7 @@ const resend = process.env.RESEND_API_KEY
   : null;
 
 const TO_EMAIL = process.env.CONTACT_TO_EMAIL ?? "jamey.mcdowell@bayes-iq.com";
-const FROM_EMAIL = process.env.CONTACT_FROM_EMAIL ?? "website@bayesiq.com";
+const FROM_EMAIL = process.env.CONTACT_FROM_EMAIL ?? "website@bayes-iq.com";
 
 const MAX_NAME_LENGTH = 200;
 const MAX_EMAIL_LENGTH = 254;

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -113,10 +113,10 @@ export default function PrivacyPage() {
               You have the right to request access to, correction of, or
               deletion of your personal data. To make a request, contact us at{" "}
               <a
-                href="mailto:privacy@bayesiq.com"
+                href="mailto:privacy@bayes-iq.com"
                 className="text-biq-text-primary underline hover:text-accent"
               >
-                privacy@bayesiq.com
+                privacy@bayes-iq.com
               </a>
               .
             </p>
@@ -127,10 +127,10 @@ export default function PrivacyPage() {
             <p className="mt-3">
               Questions about this privacy policy? Email us at{" "}
               <a
-                href="mailto:privacy@bayesiq.com"
+                href="mailto:privacy@bayes-iq.com"
                 className="text-biq-text-primary underline hover:text-accent"
               >
-                privacy@bayesiq.com
+                privacy@bayes-iq.com
               </a>
               .
             </p>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -130,10 +130,10 @@ export default function TermsPage() {
             <p className="mt-3">
               Questions about these terms? Email us at{" "}
               <a
-                href="mailto:hello@bayesiq.com"
+                href="mailto:hello@bayes-iq.com"
                 className="text-biq-text-primary underline hover:text-accent"
               >
-                hello@bayesiq.com
+                hello@bayes-iq.com
               </a>{" "}
               or use our{" "}
               <Link


### PR DESCRIPTION
## Summary
- Fix FROM_EMAIL in contact form server action (bayesiq.com → bayes-iq.com)
- Fix email addresses on privacy and terms pages
- Fix contact URL in terms source doc

The verified Resend domain is `bayes-iq.com`. Emails from `bayesiq.com` were silently dropped.

## Test plan
- [x] `npm run build` passes
- [x] Zero `@bayesiq.com` references remaining in src/ and docs/

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)