### PR TITLE
Fix Calendly URL and embed dark mode

### DIFF
--- a/docs/product/terms.md
+++ b/docs/product/terms.md
@@ -1,57 +1,84 @@
 # Terms of Service
 
-> Source of truth for `src/app/terms/page.tsx`.  
-> Effective: 2026-03-05
+> Source of truth for `src/app/terms/page.tsx`.
+> Effective: 2026-03-30
 
-BayesIQ provides data quality auditing, telemetry validation, and analytics pipeline consulting services. These terms govern your use of our website and any consulting engagement.
+BayesIQ provides governed analytics consulting services and a software platform for data governance, audit, and remediation workflows. These terms govern your use of our website, our consulting engagements, and the BayesIQ Platform.
 
 ---
 
 ## Overview
 
-BayesIQ is a services firm. We do not provide software-as-a-service, user accounts, or a consumer product. Our website is an informational site and inquiry channel. All substantive work is conducted under a separate statement of work (SOW) agreed upon with each client.
+BayesIQ operates two lines of business:
+
+1. **Consulting** — data quality auditing, telemetry validation, and analytics pipeline consulting, delivered under a statement of work (SOW) agreed upon with each client.
+2. **Platform** — a software-as-a-service (SaaS) governance platform that produces auditable chains from raw data to approved deliverables, with evidence-backed completion and governed workflows.
+
+These terms apply to both. Where a section applies to only one, it is noted.
 
 ---
 
 ## Website use
 
-This website is provided for informational purposes. You may browse freely. Content on this site — including copy, structure, and visual design — is owned by BayesIQ and may not be reproduced without permission.
+This website provides informational content, interactive demonstrations, and an inquiry channel. You may browse freely. The self-assessment tool and golden flows demonstrations are provided for evaluation purposes and do not create a service relationship. Content on this site — including copy, structure, and visual design — is owned by BayesIQ and may not be reproduced without permission.
 
 ---
 
 ## Consulting engagements
 
-All consulting engagements are governed by a separate statement of work (SOW) agreed upon before work begins. The SOW defines scope, timeline, deliverables, and fees. These terms apply in addition to any SOW.
+All consulting engagements are governed by a separate statement of work (SOW) agreed upon before work begins. The SOW defines scope, timeline, deliverables, and fees. These terms apply in addition to any SOW. In the event of a conflict between these terms and an SOW, the SOW governs.
+
+---
+
+## Platform services
+
+Access to the BayesIQ Platform is governed by a subscription agreement or an engagement SOW that includes platform access. Platform terms include:
+
+- **Availability.** We target high availability but do not guarantee uninterrupted service. Planned maintenance will be communicated in advance.
+- **Your data.** You retain ownership of all data you upload or generate through the platform. BayesIQ does not use your data for purposes other than providing the service.
+- **Data portability.** You may export your data at any time in standard formats. Upon termination, we will provide a reasonable window for data export before deletion.
+- **Account security.** You are responsible for maintaining the security of your account credentials. Notify us immediately if you suspect unauthorized access.
+- **Termination.** Either party may terminate platform access with 30 days written notice. Upon termination, we will provide data export access for 30 days, after which your data will be deleted.
 
 ---
 
 ## Confidentiality
 
-We treat all client data and systems as confidential. We are happy to sign NDAs before any engagement. We do not retain client data beyond what is necessary to complete the engagement, and we do not share client information with third parties.
+We treat all client data and systems as confidential. We are happy to sign NDAs before any engagement. We do not retain client data beyond what is necessary to provide the service, and we do not share client information with third parties except as required to deliver the service (e.g., cloud infrastructure providers) or as required by law.
 
 ---
 
 ## Data access
 
-Our auditing process uses read-only access to your data systems where required. We do not make changes to production systems unless explicitly agreed in the SOW. We do not require access to personally identifiable information (PII) to conduct most audits.
+For consulting engagements, our auditing process uses read-only access to your data systems where required. We do not make changes to production systems unless explicitly agreed in the SOW. We do not require access to personally identifiable information (PII) to conduct most audits.
+
+For platform services, data access is limited to what is necessary to operate the platform. All data is encrypted in transit and at rest.
 
 ---
 
 ## Intellectual property
 
-Deliverables produced during an engagement (audit reports, fix recommendations, architecture documents) are owned by the client upon payment in full. BayesIQ retains ownership of its proprietary tools, methods, and analysis frameworks.
+Deliverables produced during a consulting engagement (audit reports, fix recommendations, architecture documents) are owned by the client upon payment in full. Data and configurations you create within the platform are yours.
+
+BayesIQ retains ownership of its proprietary tools, methods, analysis frameworks, and the platform software itself.
 
 ---
 
 ## Limitation of liability
 
-BayesIQ provides analysis and recommendations based on the data and access provided. We do not guarantee specific outcomes. Our liability is limited to the fees paid for the specific engagement in question.
+BayesIQ provides analysis, recommendations, and software tools based on the data and access provided. We do not guarantee specific outcomes. Our liability is limited to the fees paid for the specific engagement or subscription period in question. BayesIQ is not liable for indirect, incidental, or consequential damages.
 
 ---
 
 ## Governing law
 
-These terms are governed by applicable law. Specific jurisdiction will be established in the SOW for each engagement.
+These terms are governed by applicable law. Specific jurisdiction will be established in the SOW or subscription agreement for each engagement.
+
+---
+
+## Changes to these terms
+
+We may update these terms from time to time. Material changes will be communicated via email to active clients and platform users. Continued use of our services after notification constitutes acceptance of the updated terms.
 
 ---
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,3 +86,11 @@ body {
   --biq-shadow-md: 0 4px 16px rgba(0, 0, 0, 0.3);
 }
 
+/* Force Calendly iframe to fill its container — widget.js sets a
+   tiny default height (150px) and relies on postMessage resizing
+   which is unreliable in sandboxed/embedded contexts. */
+.calendly-inline-widget iframe {
+  height: 100% !important;
+  min-height: inherit !important;
+}
+

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -9,11 +9,11 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: "Terms of Service",
-  description: "Terms of service for BayesIQ consulting engagements and website use.",
+  description: "Terms of service for BayesIQ consulting engagements, platform services, and website use.",
   openGraph: {
     title: "Terms of Service — BayesIQ",
     description:
-      "Terms of service for BayesIQ consulting engagements and website use.",
+      "Terms of service for BayesIQ consulting engagements, platform services, and website use.",
   },
 };
 
@@ -25,22 +25,38 @@ export default function TermsPage() {
           Terms of Service
         </h1>
         <p className="mt-4 text-sm text-biq-text-muted">
-          Effective: 2026-03-05
+          Effective: 2026-03-30
         </p>
 
         <div className="mt-12 space-y-10 text-sm leading-relaxed text-biq-text-secondary">
           <div>
             <h2 className="text-lg font-semibold text-biq-text-primary">Overview</h2>
             <p className="mt-3">
-              BayesIQ provides data quality auditing, telemetry validation, and
-              analytics pipeline consulting services. These terms govern your use
-              of our website and any consulting engagement.
+              BayesIQ provides governed analytics consulting services and a
+              software platform for data governance, audit, and remediation
+              workflows. These terms govern your use of our website, our
+              consulting engagements, and the BayesIQ Platform.
             </p>
             <p className="mt-3">
-              BayesIQ is a services firm. We do not provide software-as-a-service,
-              user accounts, or a consumer product. Our website is an informational
-              site and inquiry channel. All substantive work is conducted under a
-              separate statement of work (SOW) agreed upon with each client.
+              BayesIQ operates two lines of business:
+            </p>
+            <ol className="mt-3 list-decimal space-y-2 pl-5">
+              <li>
+                <strong className="text-biq-text-primary">Consulting</strong> —
+                data quality auditing, telemetry validation, and analytics
+                pipeline consulting, delivered under a statement of work (SOW)
+                agreed upon with each client.
+              </li>
+              <li>
+                <strong className="text-biq-text-primary">Platform</strong> — a
+                software-as-a-service (SaaS) governance platform that produces
+                auditable chains from raw data to approved deliverables, with
+                evidence-backed completion and governed workflows.
+              </li>
+            </ol>
+            <p className="mt-3">
+              These terms apply to both. Where a section applies to only one, it
+              is noted.
             </p>
           </div>
 
@@ -49,9 +65,13 @@ export default function TermsPage() {
               Website use
             </h2>
             <p className="mt-3">
-              This website is provided for informational purposes. You may browse
-              freely. Content on this site is owned by BayesIQ and may not be
-              reproduced without permission.
+              This website provides informational content, interactive
+              demonstrations, and an inquiry channel. You may browse freely. The
+              self-assessment tool and golden flows demonstrations are provided
+              for evaluation purposes and do not create a service relationship.
+              Content on this site — including copy, structure, and visual
+              design — is owned by BayesIQ and may not be reproduced without
+              permission.
             </p>
           </div>
 
@@ -63,8 +83,51 @@ export default function TermsPage() {
               All consulting engagements are governed by a separate statement of
               work (SOW) agreed upon before work begins. The SOW defines scope,
               timeline, deliverables, and fees. These terms apply in addition to
-              any SOW.
+              any SOW. In the event of a conflict between these terms and an SOW,
+              the SOW governs.
             </p>
+          </div>
+
+          <div>
+            <h2 className="text-lg font-semibold text-biq-text-primary">
+              Platform services
+            </h2>
+            <p className="mt-3">
+              Access to the BayesIQ Platform is governed by a subscription
+              agreement or an engagement SOW that includes platform access.
+              Platform terms include:
+            </p>
+            <ul className="mt-3 list-disc space-y-2 pl-5">
+              <li>
+                <strong className="text-biq-text-primary">Availability.</strong>{" "}
+                We target high availability but do not guarantee uninterrupted
+                service. Planned maintenance will be communicated in advance.
+              </li>
+              <li>
+                <strong className="text-biq-text-primary">Your data.</strong>{" "}
+                You retain ownership of all data you upload or generate through
+                the platform. BayesIQ does not use your data for purposes other
+                than providing the service.
+              </li>
+              <li>
+                <strong className="text-biq-text-primary">Data portability.</strong>{" "}
+                You may export your data at any time in standard formats. Upon
+                termination, we will provide a reasonable window for data export
+                before deletion.
+              </li>
+              <li>
+                <strong className="text-biq-text-primary">Account security.</strong>{" "}
+                You are responsible for maintaining the security of your account
+                credentials. Notify us immediately if you suspect unauthorized
+                access.
+              </li>
+              <li>
+                <strong className="text-biq-text-primary">Termination.</strong>{" "}
+                Either party may terminate platform access with 30 days written
+                notice. Upon termination, we will provide data export access for
+                30 days, after which your data will be deleted.
+              </li>
+            </ul>
           </div>
 
           <div>
@@ -74,8 +137,10 @@ export default function TermsPage() {
             <p className="mt-3">
               We treat all client data and systems as confidential. We are happy
               to sign NDAs before any engagement. We do not retain client data
-              beyond what is necessary to complete the engagement, and we do not
-              share client information with third parties.
+              beyond what is necessary to provide the service, and we do not
+              share client information with third parties except as required to
+              deliver the service (e.g., cloud infrastructure providers) or as
+              required by law.
             </p>
           </div>
 
@@ -84,10 +149,16 @@ export default function TermsPage() {
               Data access
             </h2>
             <p className="mt-3">
-              Our auditing process uses read-only access to your data systems
-              where required. We do not make changes to production systems unless
-              explicitly agreed in the SOW. We do not require access to personally
-              identifiable information (PII) to conduct most audits.
+              For consulting engagements, our auditing process uses read-only
+              access to your data systems where required. We do not make changes
+              to production systems unless explicitly agreed in the SOW. We do
+              not require access to personally identifiable information (PII) to
+              conduct most audits.
+            </p>
+            <p className="mt-3">
+              For platform services, data access is limited to what is necessary
+              to operate the platform. All data is encrypted in transit and at
+              rest.
             </p>
           </div>
 
@@ -96,10 +167,14 @@ export default function TermsPage() {
               Intellectual property
             </h2>
             <p className="mt-3">
-              Deliverables produced during an engagement (audit reports, fix
-              recommendations, architecture documents) are owned by the client
-              upon payment in full. BayesIQ retains ownership of its proprietary
-              tools, methods, and analysis frameworks.
+              Deliverables produced during a consulting engagement (audit
+              reports, fix recommendations, architecture documents) are owned by
+              the client upon payment in full. Data and configurations you create
+              within the platform are yours.
+            </p>
+            <p className="mt-3">
+              BayesIQ retains ownership of its proprietary tools, methods,
+              analysis frameworks, and the platform software itself.
             </p>
           </div>
 
@@ -108,10 +183,11 @@ export default function TermsPage() {
               Limitation of liability
             </h2>
             <p className="mt-3">
-              BayesIQ provides analysis and recommendations based on the data and
-              access provided. We do not guarantee specific outcomes. Our
-              liability is limited to the fees paid for the specific engagement
-              in question.
+              BayesIQ provides analysis, recommendations, and software tools
+              based on the data and access provided. We do not guarantee specific
+              outcomes. Our liability is limited to the fees paid for the
+              specific engagement or subscription period in question. BayesIQ is
+              not liable for indirect, incidental, or consequential damages.
             </p>
           </div>
 
@@ -121,7 +197,20 @@ export default function TermsPage() {
             </h2>
             <p className="mt-3">
               These terms are governed by applicable law. Specific jurisdiction
-              will be established in the SOW for each engagement.
+              will be established in the SOW or subscription agreement for each
+              engagement.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="text-lg font-semibold text-biq-text-primary">
+              Changes to these terms
+            </h2>
+            <p className="mt-3">
+              We may update these terms from time to time. Material changes will
+              be communicated via email to active clients and platform users.
+              Continued use of our services after notification constitutes
+              acceptance of the updated terms.
             </p>
           </div>
 

--- a/src/components/CalendlyEmbed.tsx
+++ b/src/components/CalendlyEmbed.tsx
@@ -13,7 +13,8 @@ import { track } from "@vercel/analytics";
 
 // ─── Configuration ────────────────────────────────────────────────────────────
 // Update this URL when the Calendly event type link changes.
-const CALENDLY_URL = "https://calendly.com/bayesiq/30min";
+const CALENDLY_URL = "https://calendly.com/jamey-mcdowell-bayes-iq/30min";
+const CALENDLY_EMBED_URL = `${CALENDLY_URL}?hide_gdpr_banner=1&hide_landing_page_details=1`;
 // ──────────────────────────────────────────────────────────────────────────────
 
 function handleBookClick() {
@@ -59,9 +60,10 @@ export default function CalendlyEmbed() {
        * alternative in case the widget script is blocked or fails.
        */}
       <div
-        className="calendly-inline-widget overflow-hidden rounded-xl border border-biq-border-subtle"
-        data-url={CALENDLY_URL}
-        style={{ minHeight: "700px", width: "100%" }}
+        data-theme="light"
+        className="calendly-inline-widget rounded-xl border border-biq-border-subtle bg-white"
+        data-url={CALENDLY_EMBED_URL}
+        style={{ minHeight: "950px", width: "100%" }}
         role="region"
         aria-label="Calendly booking calendar"
       >

--- a/src/components/golden-flows/GoldenFlowsCTA.tsx
+++ b/src/components/golden-flows/GoldenFlowsCTA.tsx
@@ -67,7 +67,7 @@ export default function GoldenFlowsCTA({
             Book 20&ndash;30 minutes. We&apos;ll tell you honestly what we see.
           </p>
           <a
-            href="https://calendly.com/bayesiq/30min"
+            href="https://calendly.com/jamey-mcdowell-bayes-iq/30min"
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => trackCtaClick("book_session", vertical || "unknown")}


### PR DESCRIPTION
Fix Calendly scheduling URL (old account showed login page) and force light background on embed for dark mode. No issue